### PR TITLE
chore: prepare Little Canary 0.3.3 release truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install pytest pytest-cov ruff==0.15.14
+          pip install ".[dev]"
 
       - name: Lint with ruff
         run: ruff check little_canary/ tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Benchmark and latency figures in entries before `0.3.3` are historical release n
 
 ## [0.3.3] - Unreleased
 
-`0.3.2` was not published and is not reused.
+Release-candidate truth: the package, source metadata, and documented `demo`
+commands are `0.3.3`. GitHub `v0.3.1` was source-only, PyPI remained on
+`0.3.0`, and `0.3.2` was not published and is not reused.
 
 ### Added
 
@@ -24,6 +26,10 @@ Benchmark and latency figures in entries before `0.3.3` are historical release n
 - Default pipeline layer snapshots retain signal categories and scores but omit raw canary responses and signal-evidence excerpts before callbacks or serialization.
 - The HTTP adapter no longer skips one-to-five-character inputs or silently truncates attack suffixes; malformed, empty, and oversized requests are explicit errors.
 - Version and organization metadata are coherent, and an unrelated DOI has been removed.
+- CI installs the declared development tool set instead of carrying a second
+  Ruff pin; mypy stays below version 2 while the project configuration targets
+  Python 3.9; and the Python 3.10+ `pip-audit` tool is excluded only from
+  Python 3.9 development environments.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -14,23 +14,34 @@ untrusted text
 
 Little Canary is an inbound risk sensor, not a security guarantee or an agent runtime.
 
+## Release truth
+
+Source candidates, GitHub releases, and registry builds are separate evidence
+surfaces. This checkout is the `0.3.3` release candidate. GitHub `v0.3.1` was
+source-only, `0.3.2` was intentionally not published or reused, and PyPI
+remained on `0.3.0`. The `demo` commands documented below require `0.3.3`;
+verify the installed artifact with `little-canary --version`.
+
 ## Install
 
 Little Canary supports Python 3.9–3.12.
 
+For the `0.3.3` registry artifact:
+
 ```bash
-python -m pip install little-canary
+python -m pip install "little-canary==0.3.3"
 little-canary --version
 ```
 
-That is the post-publication registry journey. For an unreleased candidate,
-install its exact wheel or sdist instead; the public registry may still resolve
-an earlier version and is not proof of candidate behavior.
+Before publication, install the exact candidate wheel or source checkout
+instead. An unpinned registry install may resolve `0.3.0`, whose CLI exposes
+`serve` but not the `0.3.3` `demo` command.
 
 For a source checkout:
 
 ```bash
-python -m pip install -e ".[dev]"
+python -m pip install .
+little-canary --version
 ```
 
 ## Run the evidence gates without writing Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ benchmark = [
 dev = [
     "pytest>=8.4.2",
     "pytest-cov>=7.1.0",
-    "mypy>=1.19.1",
+    "mypy>=1.19.1,<2",
     "ruff>=0.15.22",
-    "pip-audit>=2.10.1",
+    "pip-audit>=2.10.1; python_version >= '3.10'",
     "anthropic>=0.117.0",
 ]
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,49 @@
+"""Release-version and repository-identity consistency checks."""
+
+import json
+import re
+from pathlib import Path
+
+from little_canary import __version__
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _match(relative_path: str, pattern: str) -> str:
+    match = re.search(pattern, _read(relative_path), flags=re.MULTILINE)
+    assert match is not None, f"{relative_path} does not match {pattern!r}"
+    return match.group(1)
+
+
+def test_release_version_surfaces_are_aligned():
+    versions = {
+        __version__,
+        _match("pyproject.toml", r'^version = "([^"]+)"$'),
+        _match("CITATION.cff", r'^version: "([^"]+)"$'),
+        json.loads(_read(".zenodo.json"))["version"],
+    }
+
+    assert versions == {__version__}
+    assert _match("CHANGELOG.md", r"^## \[([^\]]+)\] - ") == __version__
+
+
+def test_current_release_metadata_uses_canonical_repository_identity():
+    canonical_repository = "https://github.com/hermes-labs-ai/little-canary"
+    current_metadata = {
+        relative_path: _read(relative_path)
+        for relative_path in (
+            "pyproject.toml",
+            "CITATION.cff",
+            ".zenodo.json",
+            "README.md",
+            "llms.txt",
+        )
+    }
+
+    assert canonical_repository in current_metadata["pyproject.toml"]
+    assert canonical_repository in current_metadata["CITATION.cff"]
+    assert all("roli-lpci" not in text for text in current_metadata.values())


### PR DESCRIPTION
## What changed
- makes the 0.3.3 source, GitHub, and PyPI release state explicit
- aligns CI with the declared development dependency set
- adds deterministic version and canonical-repository metadata checks

## Verification
- 341 tests pass on Python 3.9, 3.10, 3.11, and 3.12
- coverage 90.96%; Ruff passes
- wheel/sdist build and Twine checks pass
- fresh-wheel install, `pip check`, version, help, serve help, and no-egress replay behavior verified
- exact base/head review PASS with zero findings

This PR prepares the public 0.3.3 source truth. The GitHub release and PyPI publication follow only after main is green.