### PR TITLE
Docs: reflect published 0.3.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Little Canary is an inbound risk sensor, not a security guarantee or an agent ru
 ## Release truth
 
 Source candidates, GitHub releases, and registry builds are separate evidence
-surfaces. This checkout is the `0.3.3` release candidate. GitHub `v0.3.1` was
-source-only, `0.3.2` was intentionally not published or reused, and PyPI
-remained on `0.3.0`. The `demo` commands documented below require `0.3.3`;
-verify the installed artifact with `little-canary --version`.
+surfaces. This checkout, GitHub tag `v0.3.3`, and the registry artifact now
+identify the same release: PyPI currently publishes `0.3.3`. GitHub `v0.3.1`
+was source-only and `0.3.2` was intentionally not published or reused. The
+`demo` commands documented below require `0.3.3`; verify the installed artifact
+with `little-canary --version`.
 
 ## Install
 
@@ -33,11 +34,7 @@ python -m pip install "little-canary==0.3.3"
 little-canary --version
 ```
 
-Before publication, install the exact candidate wheel or source checkout
-instead. An unpinned registry install may resolve `0.3.0`, whose CLI exposes
-`serve` but not the `0.3.3` `demo` command.
-
-For a source checkout:
+For development from a source checkout:
 
 ```bash
 python -m pip install .

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -47,3 +47,11 @@ def test_current_release_metadata_uses_canonical_repository_identity():
     assert canonical_repository in current_metadata["pyproject.toml"]
     assert canonical_repository in current_metadata["CITATION.cff"]
     assert all("roli-lpci" not in text for text in current_metadata.values())
+
+
+def test_readme_describes_the_published_registry_release():
+    readme = _read("README.md")
+
+    assert f"PyPI currently publishes `{__version__}`" in readme
+    assert "Before publication" not in readme
+    assert "PyPI remained on `0.3.0`" not in readme


### PR DESCRIPTION
## Summary
- Align the README release truth with published version 0.3.3.
- Extend the release-metadata regression test.

## Validation
- 342 tests and changed-path Ruff passed in the reviewed boundary.

## Boundaries
- Draft review only. No merge, package release, tag, deployment, or announcement.