### PR TITLE
docs: cite Zenodo concept DOIs for the two 2026-08-06 technical notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ documents Little Canary's pre-execution sensing architecture and the separation
 between routing disposition and inspection coverage. It does not claim
 universal detection, formal security, or aggregate accuracy for the current
 release. Cite the archived Version 1.0 record at
-[10.5281/zenodo.21818565](https://doi.org/10.5281/zenodo.21818565):
+[10.5281/zenodo.21818564](https://doi.org/10.5281/zenodo.21818564):
 
 ```bibtex
 @misc{bosch2026behavioralcanarying,
@@ -30,8 +30,8 @@ release. Cite the archived Version 1.0 record at
                   Probes with Explicit Coverage Semantics},
   year         = {2026},
   publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.21818565},
-  url          = {https://doi.org/10.5281/zenodo.21818565},
+  doi          = {10.5281/zenodo.21818564},
+  url          = {https://doi.org/10.5281/zenodo.21818564},
   note         = {Technical note}
 }
 ```


### PR DESCRIPTION
## What changed

Switches the two 2026-08-06 technical notes from version DOIs to their Zenodo **concept DOIs**:

| Paper | Now cited as |
|---|---|
| Tool Differentia | `10.5281/zenodo.21817243` |
| Behavioral Canarying | `10.5281/zenodo.21818564` |

## Why

Both papers now have two versions on Zenodo (v1.0 and v1.0.1), and Zenodo mints a new DOI for
every version. A version DOI therefore goes stale on each version bump — which is what just
happened: v1.0.1 was published, the website picked up the new version DOIs, and every surface
still pinned to v1.0 fell out of sync.

A concept DOI is version-agnostic and always resolves to the latest version, so this cannot
recur. It also matches what the v1.0.1 PDF cover pages already print about themselves.

## Not changed

- Zenodo **record** URLs (`zenodo.org/records/<id>/files/...`) stay version-pinned. Those are
  record ids, not DOIs; the concept id does not serve files, so rewriting them would break the
  PDF links.
- The four single-version papers are untouched. Their DOIs are already propagated to ORCID and
  to outside citations, and they cannot go stale.
- No paper content, no claims, no version history.

## Verification

- All six concept DOIs resolve (HTTP 200 through `doi.org`).
- Replacement was done by a guarded script matching only the `10.5281/zenodo.<id>` DOI form,
  never the record-URL form.
- Zero stale version DOIs remain; PDF download links confirmed intact.
