### PR TITLE
ci: incorporate setuptools/requests bumps behind Python 3.9 markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "wheel"]
+requires = [
+    "setuptools>=82.0.1,<83; python_version < '3.10'",
+    "setuptools>=83.0.0; python_version >= '3.10'",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -25,7 +29,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "requests>=2.32.5",
+    "requests>=2.32.5,<2.33; python_version < '3.10'",
+    "requests>=2.34.2; python_version >= '3.10'",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requests>=2.32.5
+requests>=2.32.5,<2.33; python_version < '3.10'
+requests>=2.34.2; python_version >= '3.10'


### PR DESCRIPTION
Dependabot PRs #48 (setuptools >=83) and #40 (requests >=2.34.2) fail CI: both new versions require Python >=3.10, and the 3.9 job's failure cancels the rest of the matrix via fail-fast. This PR incorporates both bumps behind PEP 508 markers, mirroring the existing pip-audit marker pattern: 3.10+ gets the new floors, 3.9 stays on the latest compatible series (setuptools 82.x, requests 2.32.x).

Note: the requests split touches [project.dependencies], so Python 3.9 installs are capped at requests<2.33 until 3.9 support is dropped. The caps currently exclude nothing that PyPI metadata does not already exclude for 3.9.

Verified: resolution + ruff + full test suite (342 passed) on 3.9 through 3.12.

Supersedes #48 and #40 (close both promptly after merge so a dependabot rebase cannot re-arm auto-merge on #40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
