### PR TITLE
Add stable CodeMeta software metadata

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,46 @@
+{
+  "@context": "https://w3id.org/codemeta/3.1",
+  "@type": "SoftwareSourceCode",
+  "name": "little-canary",
+  "description": "Prompt injection detection for LLM apps using sacrificial canary-model probes and structural preflight checks",
+  "version": "0.3.3",
+  "identifier": "https://doi.org/10.5281/zenodo.21543681",
+  "codeRepository": "https://github.com/hermes-labs-ai/little-canary",
+  "issueTracker": "https://github.com/hermes-labs-ai/little-canary/issues",
+  "continuousIntegration": "https://github.com/hermes-labs-ai/little-canary/actions",
+  "downloadUrl": "https://pypi.org/project/little-canary/0.3.3/",
+  "license": "https://spdx.org/licenses/Apache-2.0",
+  "programmingLanguage": "Python",
+  "runtimePlatform": "Python >=3.9",
+  "applicationCategory": "Security",
+  "developmentStatus": "active",
+  "author": {
+    "@id": "https://orcid.org/0009-0005-4896-1112",
+    "@type": "Person",
+    "givenName": "Rolando",
+    "familyName": "Bosch Rodriguez",
+    "affiliation": {
+      "@type": "Organization",
+      "name": "Hermes Labs"
+    }
+  },
+  "maintainer": {
+    "@id": "https://orcid.org/0009-0005-4896-1112",
+    "@type": "Person",
+    "givenName": "Rolando",
+    "familyName": "Bosch Rodriguez",
+    "email": "roli@hermes-labs.ai",
+    "affiliation": {
+      "@type": "Organization",
+      "name": "Hermes Labs"
+    }
+  },
+  "keywords": [
+    "AI reliability",
+    "LLM reliability",
+    "prompt-injection detection",
+    "behavioral probe",
+    "sacrificial canary model",
+    "LLM security"
+  ]
+}

--- a/codemeta.json
+++ b/codemeta.json
@@ -12,8 +12,6 @@
   "license": "https://spdx.org/licenses/Apache-2.0",
   "programmingLanguage": "Python",
   "runtimePlatform": "Python >=3.9",
-  "applicationCategory": "Security",
-  "developmentStatus": "active",
   "author": {
     "@id": "https://orcid.org/0009-0005-4896-1112",
     "@type": "Person",

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -39,6 +39,7 @@ def test_current_release_metadata_uses_canonical_repository_identity():
             "pyproject.toml",
             "CITATION.cff",
             ".zenodo.json",
+            "codemeta.json",
             "README.md",
             "llms.txt",
         )
@@ -47,6 +48,19 @@ def test_current_release_metadata_uses_canonical_repository_identity():
     assert canonical_repository in current_metadata["pyproject.toml"]
     assert canonical_repository in current_metadata["CITATION.cff"]
     assert all("roli-lpci" not in text for text in current_metadata.values())
+
+
+def test_codemeta_tracks_current_release_metadata():
+    codemeta = json.loads(_read("codemeta.json"))
+    canonical_repository = "https://github.com/hermes-labs-ai/little-canary"
+    license_id = _match("pyproject.toml", r'^license = "([^"]+)"$')
+
+    assert codemeta["@context"] == "https://w3id.org/codemeta/3.1"
+    assert codemeta["@type"] == "SoftwareSourceCode"
+    assert codemeta["version"] == __version__
+    assert codemeta["codeRepository"] == canonical_repository
+    assert codemeta["downloadUrl"] == f"https://pypi.org/project/little-canary/{__version__}/"
+    assert codemeta["license"] == f"https://spdx.org/licenses/{license_id}"
 
 
 def test_readme_describes_the_published_registry_release():

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -54,13 +54,31 @@ def test_codemeta_tracks_current_release_metadata():
     codemeta = json.loads(_read("codemeta.json"))
     canonical_repository = "https://github.com/hermes-labs-ai/little-canary"
     license_id = _match("pyproject.toml", r'^license = "([^"]+)"$')
+    citation_orcid = _match("CITATION.cff", r'^    orcid: "([^"]+)"$')
+    citation_given_name = _match("CITATION.cff", r'^    given-names: "([^"]+)"$')
+    citation_family_name = _match("CITATION.cff", r'^  - family-names: "([^"]+)"$')
+    citation_affiliation = _match("CITATION.cff", r'^    affiliation: "([^"]+)"$')
+    maintainer_email = _match("pyproject.toml", r'^    \{name = "Hermes Labs", email = "([^"]+)"\},$')
+    zenodo_creator = json.loads(_read(".zenodo.json"))["creators"][0]
+    author = codemeta["author"]
+    maintainer = codemeta["maintainer"]
 
     assert codemeta["@context"] == "https://w3id.org/codemeta/3.1"
     assert codemeta["@type"] == "SoftwareSourceCode"
     assert codemeta["version"] == __version__
+    assert codemeta["identifier"] == "https://doi.org/10.5281/zenodo.21543681"
     assert codemeta["codeRepository"] == canonical_repository
     assert codemeta["downloadUrl"] == f"https://pypi.org/project/little-canary/{__version__}/"
     assert codemeta["license"] == f"https://spdx.org/licenses/{license_id}"
+    assert author["@id"] == maintainer["@id"] == citation_orcid
+    assert zenodo_creator["orcid"] == citation_orcid.rsplit("/", maxsplit=1)[-1]
+    assert author["givenName"] == maintainer["givenName"] == citation_given_name
+    assert author["familyName"] == maintainer["familyName"] == citation_family_name
+    assert zenodo_creator["name"] == f"{citation_family_name}, {citation_given_name}"
+    assert author["affiliation"]["name"] == maintainer["affiliation"]["name"] == citation_affiliation
+    assert zenodo_creator["affiliation"] == citation_affiliation
+    assert maintainer["email"] == maintainer_email
+    assert "dateModified" not in codemeta
 
 
 def test_readme_describes_the_published_registry_release():


### PR DESCRIPTION
## Summary

Add a machine-readable CodeMeta record for Little Canary and guard its release-linked fields against drift.

## Changes

- pin the stable CodeMeta 3.1 JSON-LD context
- describe the current 0.3.3 software release, canonical repository, versioned PyPI page, Apache-2.0 license, verified ORCID attribution, and release-specific Zenodo software DOI
- omit volatile `dateModified` metadata and exclude the separate technical-note DOI
- add deterministic checks for the context, type, version, repository, PyPI URL, license, and canonical organization identity

## Validation

- `ruff check little_canary tests`
- `pytest -q` — 343 passed on Python 3.12
- JSON-LD expansion with PyLD against `https://w3id.org/codemeta/3.1` — 17 recognized properties
- public metadata readback from GitHub, PyPI, Zenodo, ORCID, and SPDX

## Notes

The repository baseline currently has pre-existing mypy failures (including its Python 3.9 configuration under current mypy); this metadata-only change does not alter those source files, and the project CI does not run mypy.