### PR TITLE
Link Behavioral Canarying in software metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -20,5 +20,12 @@
     "sacrificial canary model",
     "LLM security"
   ],
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.21818564",
+      "relation": "isDocumentedBy",
+      "scheme": "doi"
+    }
+  ],
   "version": "0.3.3"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,3 +20,14 @@ keywords:
   - behavioral probe
   - sacrificial canary model
   - LLM security
+references:
+  - type: report
+    authors:
+      - family-names: "Bosch"
+        given-names: "Rolando"
+        orcid: "https://orcid.org/0009-0005-4896-1112"
+        affiliation: "Hermes Labs"
+    title: "Behavioral Canarying for Prompt Injection: Powerless Model Probes with Explicit Coverage Semantics"
+    year: 2026
+    doi: "10.5281/zenodo.21818564"
+    url: "https://doi.org/10.5281/zenodo.21818564"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Little Canary is an inbound risk sensor, not a security guarantee or an agent ru
 documents Little Canary's pre-execution sensing architecture and the separation
 between routing disposition and inspection coverage. It does not claim
 universal detection, formal security, or aggregate accuracy for the current
-release. Cite the archived Version 1.0 record at
+release. Cite the version-independent concept DOI at
 [10.5281/zenodo.21818564](https://doi.org/10.5281/zenodo.21818564):
 
 ```bibtex


### PR DESCRIPTION
## What changed

- links the Behavioral Canarying concept DOI from `.zenodo.json` with `isDocumentedBy`
- adds the technical note as a scoped CFF 1.2 reference
- describes the DOI correctly as the version-independent concept DOI

## Why

The technical note explicitly documents the architecture implemented in Little Canary and identifies Little Canary as its open-source reference implementation. The existing README linked the concept DOI but described it as an archived Version 1.0 record.

This adds documentation lineage only. It does not add a performance, validation, or security claim.

## Checks

- `python -m json.tool .zenodo.json`
- `uvx --from cffconvert cffconvert --validate -i CITATION.cff`
- `git diff --check`
- DataCite readback for `10.5281/zenodo.21818564`
- source inspection of `hermes-labs-ai/hermes-publications/papers/behavioral-canarying/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added references to related software documentation and a supporting research report.
  * Updated citation guidance to use the version-independent concept DOI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->