### PR TITLE
ci: pin workflow action references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +39,7 @@ jobs:
 
       - name: Upload coverage (Python 3.12 only)
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,12 @@ jobs:
     permissions:
       id-token: write   # required for PyPI Trusted Publishing (OIDC) — no API token needed
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -31,4 +33,4 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Summary

Pins every existing third-party GitHub Actions reference to a reviewed immutable upstream commit, retaining version comments and existing workflow permissions. Checkout steps now disable persisted credentials.

## Pinned action mapping

- `actions/checkout@v7` → `3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`)
- `actions/setup-python@v7` → `5fda3b95a4ea91299a34e894583c3862153e4b97` (`v7.0.0`)
- `actions/upload-artifact@v7` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (`v7.0.1`)
- `pypa/gh-action-pypi-publish@release/v1` → `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` (`v1.14.2`)
- `dependabot/fetch-metadata@v3` → `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` (`v3.1.0`)

## Verification

- Parsed all three workflow YAML files successfully.
- Confirmed every `uses:` reference is a full 40-character SHA.
- `pytest -q` — 343 passed.
- `ruff check little_canary tests` — passed.

## Existing baseline note

`mypy little_canary` remains failing without changes from this PR under the project-allowed Mypy 2.3.1: its configured `python_version = 3.9` is unsupported by that Mypy version, followed by 14 existing typing errors. This workflow-only PR deliberately does not change the type-checking baseline.
