### PR TITLE
ci: isolate PyPI publishing identity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,11 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Build and publish to PyPI
+  build:
+    name: Build release distributions
     runs-on: ubuntu-latest
     permissions:
-      id-token: write   # required for PyPI Trusted Publishing (OIDC) — no API token needed
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -27,10 +27,39 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Verify release tag matches package version
+        run: |
+          package_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          test "${GITHUB_REF_NAME}" = "v${package_version}"
+
       - name: Build sdist and wheel
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip build twine
           python -m build
+          python -m twine check dist/*
+
+      - name: Upload release distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/little-canary/
+    permissions:
+      contents: read
+      id-token: write   # required for PyPI Trusted Publishing (OIDC) — no API token needed
+    steps:
+      - name: Download release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -87,3 +87,22 @@ def test_readme_describes_the_published_registry_release():
     assert f"PyPI currently publishes `{__version__}`" in readme
     assert "Before publication" not in readme
     assert "PyPI remained on `0.3.0`" not in readme
+
+
+def test_publish_workflow_keeps_build_privileges_away_from_publishing():
+    workflow = _read(".github/workflows/publish.yml")
+    build_workflow, publish_workflow = workflow.split("  publish:\n", maxsplit=1)
+    build_job = build_workflow.split("  build:\n", maxsplit=1)[1]
+
+    assert "  release:\n    types: [published]" in workflow
+    assert "  build:\n" in workflow
+    assert "    permissions:\n      contents: read\n" in build_job
+    assert "id-token: write" not in build_job
+    assert 'test "${GITHUB_REF_NAME}" = "v${package_version}"' in build_job
+    assert "python -m build" in build_job
+    assert "python -m twine check dist/*" in build_job
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in build_job
+    assert "    needs: build\n" in publish_workflow
+    assert "      contents: read\n      id-token: write" in publish_workflow
+    assert "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" in publish_workflow
+    assert "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33" in publish_workflow


### PR DESCRIPTION
## Summary

Separates release artifact construction and validation from PyPI trusted publishing. The build job has only read access; only the publish job receives OIDC after it downloads the validated artifact.

The release trigger remains `release: [published]`, and the build now rejects a Release whose tag is not exactly `v<project.version>`.

## Immutable action mapping

- `actions/checkout@v7.0.1` → `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `actions/setup-python@v7.0.0` → `5fda3b95a4ea91299a34e894583c3862153e4b97`
- `actions/upload-artifact@v7.0.1` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
- `actions/download-artifact@v8.0.1` → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`
- `pypa/gh-action-pypi-publish@release/v1` → `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` (`v1.14.2`)

## Verification

- Focused regression test was red against the single OIDC build/publish job, then green after the split.
- Mutation proof: replacing `id-token: write` with `id-token: none` makes the regression test fail.
- `python -m build` and `python -m twine check dist/*` passed.
- `pytest -q` — 344 passed.
- `ruff check little_canary tests` passed.
- YAML semantic validation confirmed `build` has only `contents: read`, while `publish` needs build and has explicit `contents: read` plus `id-token: write`.
