### PR TITLE
ci: validate Python 3.13 source compatibility

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Brief description of what this PR does and why.
 - [ ] Compared the exact structural decision vector (if structural logic changed)
 - [ ] Ran case-level controls on a dedicated, provenance-bound model runtime (if behavioral/model behavior changed)
 - [ ] Recorded benchmark runner egress, errors, degraded cases, and evidence type; did not infer a rate from incomplete runs
-- [ ] Tested on the declared Python 3.9–3.13 support range
+- [ ] Tested source/next-release support on Python 3.9–3.13 (published `0.3.3` metadata advertises through 3.12)
 - [ ] Exercised/degraded/disabled/skipped coverage states remain truthful
 - [ ] Built and clean-installed the exact wheel and sdist when packaging or first use changed
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Brief description of what this PR does and why.
 - [ ] Compared the exact structural decision vector (if structural logic changed)
 - [ ] Ran case-level controls on a dedicated, provenance-bound model runtime (if behavioral/model behavior changed)
 - [ ] Recorded benchmark runner egress, errors, degraded cases, and evidence type; did not infer a rate from incomplete runs
-- [ ] Tested on the declared Python 3.9–3.12 support range
+- [ ] Tested on the declared Python 3.9–3.13 support range
 - [ ] Exercised/degraded/disabled/skipped coverage states remain truthful
 - [ ] Built and clean-installed the exact wheel and sdist when packaging or first use changed
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Open a [feature request](https://github.com/hermes-labs-ai/little-canary/issues/
 - Include a description of what changed and why
 - If adding detection patterns, include example inputs that trigger them
 - If changing scoring or mode logic, include before/after benchmark results
-- Maintain the declared Python 3.9–3.12 support range
+- Maintain the declared Python 3.9–3.13 support range
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ Open a [feature request](https://github.com/hermes-labs-ai/little-canary/issues/
 - Include a description of what changed and why
 - If adding detection patterns, include example inputs that trigger them
 - If changing scoring or mode logic, include before/after benchmark results
-- Maintain the declared Python 3.9–3.13 support range
+- Maintain source/next-release Python 3.9–3.13 support; published `0.3.3`
+  metadata advertises Python 3.9–3.12 until a new release is published
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ with `little-canary --version`.
 
 ## Install
 
-Little Canary supports Python 3.9–3.12.
+Little Canary supports Python 3.9–3.13.
 
 For the `0.3.3` registry artifact:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ with `little-canary --version`.
 
 ## Install
 
-Little Canary supports Python 3.9–3.13.
+Source `main` and the next release support Python 3.9–3.13. The published
+`0.3.3` package metadata advertises Python 3.9–3.12.
 
 For the `0.3.3` registry artifact:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Security",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]


### PR DESCRIPTION
## Summary

Validates Python 3.13 compatibility for source `main` and the next release, adds that source support to CI and package metadata, and qualifies public documentation accordingly.

The published PyPI `0.3.3` artifact still advertises Python 3.9–3.12. This PR does not publish, retag, or bump a version; the 3.13 classifier will reach PyPI only with a future release.

## Python 3.13 compatibility evidence

- Fresh Python 3.13.5 environment installed `.[dev]` successfully.
- Exact CI quality gate passed before source-support edits: `pytest --cov=little_canary --cov-report=xml --cov-report=term-missing` (344 passed; 90.96% coverage) and `ruff check little_canary/ tests/`.
- Full `pytest -q` and Ruff passed again after the documentation qualification.

## Scope

- Adds `3.13` to the source CI matrix and the next-release PyPI classifier.
- README, contributor guidance, and PR checklist now distinguish source/next-release 3.13 support from published `0.3.3` metadata.
