### PR TITLE
docs: add Little Canary product links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Prompt-injection sensing through a powerless sacrificial model.
 
+**Links:** [Website](https://littlecanary.ai) · [Hermes Labs product page](https://hermes-labs.ai/little-canary)
+
 Little Canary lets untrusted language affect a small model with no application tools or authority, then inspects that model's response for compromise residue before your agent acts. Structural checks catch known input shapes; the distinctive behavioral layer asks what the input *did to the canary*.
 
 ```text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dev = [
 little-canary = "little_canary.cli:main"
 
 [project.urls]
-Homepage = "https://hermes-labs.ai"
+Homepage = "https://littlecanary.ai"
+"Hermes Labs" = "https://hermes-labs.ai/little-canary"
 Repository = "https://github.com/hermes-labs-ai/little-canary"
 Issues = "https://github.com/hermes-labs-ai/little-canary/issues"
 Documentation = "https://github.com/hermes-labs-ai/little-canary#readme"


### PR DESCRIPTION
## Summary\n\n- add above-fold links to the standalone Little Canary website and the Hermes Labs product page\n- make the standalone site the package Homepage\n- add the Hermes Labs product page as a separate package URL\n\n## Validation\n\n- git diff --check\n- TOML parse\n- wheel build and Project-URL metadata inspection\n- both product URLs: HTTP 200 with canonical URLs preserved\n- ruff check little_canary tests\n- pytest: 346 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prominent links to the project website and Hermes Labs product page in the README.
  * Updated project metadata with the latest homepage and organization URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->