### PR TITLE
ci: dogfood LintLang with native SARIF

### DIFF
--- a/.github/workflows/lintlang.yml
+++ b/.github/workflows/lintlang.yml
@@ -1,0 +1,30 @@
+name: LintLang
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  language-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Scan agent instructions
+        uses: hermes-labs-ai/lintlang@6be2907d557e534732865d3a3a3c55ea5f1a0ec9 # v0.4.1
+        with:
+          path: "AGENTS.md"
+          fail-on: fail
+          sarif-file: lintlang.sarif
+
+      - name: Upload SARIF
+        if: always() && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          sarif_file: lintlang.sarif


### PR DESCRIPTION
Adds a least-privilege LintLang SARIF workflow pinned to the immutable 0.4.1 release commit. Initial dogfood result passes the HIGH/CRITICAL blocking threshold while leaving MEDIUM/INFO findings visible. No findings are suppressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated language-contract linting for pull requests and pushes to the main branch.
  * Linting results are uploaded for review through the repository’s security reporting interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->