### PR TITLE
fix: merge Dependabot updates after required checks

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,10 @@ jobs:
 
       - name: Auto-merge minor and patch updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          gh pr checks --required --watch --fail-fast "$PR_URL"
+          gh pr merge --squash --match-head-commit "$HEAD_SHA" "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -130,3 +130,15 @@ def test_publish_workflow_keeps_build_privileges_away_from_publishing():
     assert "      contents: read\n      id-token: write" in publish_workflow
     assert "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" in publish_workflow
     assert "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33" in publish_workflow
+
+
+def test_dependabot_merge_waits_for_required_checks_without_repository_auto_merge():
+    workflow = _read(".github/workflows/dependabot-auto-merge.yml")
+
+    wait = 'gh pr checks --required --watch --fail-fast "$PR_URL"'
+    merge = 'gh pr merge --squash --match-head-commit "$HEAD_SHA" "$PR_URL"'
+    assert wait in workflow
+    assert merge in workflow
+    assert workflow.index(wait) < workflow.index(merge)
+    assert "gh pr merge --auto" not in workflow
+    assert "HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in workflow


### PR DESCRIPTION
## Summary

- wait for the exact required CI checks on the inspected Dependabot head SHA
- squash-merge only that verified commit after the checks pass
- avoid repository auto-merge, which is disabled and caused PRs #61 and #62 to fail

## Validation

- 347 tests passed
- targeted Ruff passed
- actionlint passed
- live required-check watcher tests passed

Closes the automation failure affecting #61 and #62.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependabot pull requests now wait for all required checks to pass before merging.
  * Merges are performed only against the verified pull request commit, improving merge reliability.
* **Tests**
  * Added coverage to verify the updated Dependabot merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->