### PR TITLE
Add Gemini CLI pre-agent gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,33 @@ Every accepted non-empty string reaches the pipeline, including one-character in
 
 The loopback server has no authentication, TLS, concurrency hardening, or remote-deployment design in this release.
 
+## Gemini CLI extension
+
+This repository is also a Gemini CLI extension. It uses Gemini CLI's
+`BeforeAgent` hook to screen the exact current prompt before the agent loop and
+deny the run when Little Canary returns `safe: false`.
+
+Start the loopback server in blocking mode, then validate and install a source
+checkout. This integration was verified with Gemini CLI 0.32.1:
+
+```bash
+little-canary serve --mode block
+gemini extensions validate .
+gemini extensions install . --consent
+```
+
+The hook calls only `http://127.0.0.1:18421/check` by default and completes its
+request within three seconds. Transport errors, malformed responses, and
+unexercised behavioral coverage are visibly fail-open by default; they are not
+reported as a clean pass. Set `LITTLE_CANARY_FAILURE_MODE=deny` in the Gemini
+process environment for fail-closed behavior. `LITTLE_CANARY_ENDPOINT` may
+select another loopback HTTP `/check` URL, and `LITTLE_CANARY_TIMEOUT_MS` may be
+set from 100 through 5000.
+
+This extension blocks one Gemini agent run at its pre-agent boundary. It does
+not establish a general security guarantee or replace least privilege and tool
+policy.
+
 ## Evidence labels and limitations
 
 Behavioral evidence is labeled:

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "little-canary",
+  "version": "0.3.4",
+  "description": "Blocks Gemini CLI agent runs when a local Little Canary server rejects the prompt."
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "little-canary-before-agent",
+            "description": "Screen the prompt before Gemini CLI starts the agent loop.",
+            "command": "python3 ${extensionPath}/scripts/little_canary_before_agent.py",
+            "timeout": 7000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/little_canary_before_agent.py
+++ b/scripts/little_canary_before_agent.py
@@ -9,12 +9,13 @@ import sys
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
-from urllib.request import Request, urlopen
+from urllib.request import ProxyHandler, Request, build_opener
 
 DEFAULT_ENDPOINT = "http://127.0.0.1:18421/check"
 DEFAULT_TIMEOUT_MS = 3000
 MAX_HOOK_INPUT_BYTES = 1024 * 1024
 MAX_RESPONSE_BYTES = 64 * 1024
+DIRECT_OPENER = build_opener(ProxyHandler({}))
 
 
 def _output(decision: str, reason: str, *, system_message: str | None = None) -> dict[str, Any]:
@@ -80,7 +81,7 @@ def evaluate(
     hook_input: dict[str, Any],
     env: dict[str, str],
     *,
-    opener: Any = urlopen,
+    opener: Any = DIRECT_OPENER.open,
 ) -> dict[str, Any]:
     try:
         failure_mode = _failure_mode(env)

--- a/scripts/little_canary_before_agent.py
+++ b/scripts/little_canary_before_agent.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Gemini CLI BeforeAgent adapter for Little Canary's loopback HTTP server."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:18421/check"
+DEFAULT_TIMEOUT_MS = 3000
+MAX_HOOK_INPUT_BYTES = 1024 * 1024
+MAX_RESPONSE_BYTES = 64 * 1024
+
+
+def _output(decision: str, reason: str, *, system_message: str | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"decision": decision, "reason": reason}
+    if system_message:
+        result["systemMessage"] = system_message
+    return result
+
+
+def _failure(reason: str, failure_mode: str) -> dict[str, Any]:
+    message = f"Little Canary screening unavailable: {reason}."
+    if failure_mode == "deny":
+        return _output("deny", f"{message} Prompt denied by configured fail-closed policy.")
+    return _output(
+        "allow",
+        f"{message} Prompt allowed by configured fail-open policy.",
+        system_message=f"{message} Gemini CLI continued because Little Canary is fail-open.",
+    )
+
+
+def _failure_mode(env: dict[str, str]) -> str:
+    failure_mode = env.get("LITTLE_CANARY_FAILURE_MODE", "allow").strip().lower()
+    if failure_mode not in {"allow", "deny"}:
+        raise ValueError("failure mode must be 'allow' or 'deny'")
+    return failure_mode
+
+
+def _settings(env: dict[str, str]) -> tuple[str, int]:
+    endpoint = env.get("LITTLE_CANARY_ENDPOINT", DEFAULT_ENDPOINT)
+    parsed = urlsplit(endpoint)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.path != "/check"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("endpoint must be an HTTP loopback /check URL without credentials or query data")
+
+    try:
+        timeout_ms = int(env.get("LITTLE_CANARY_TIMEOUT_MS", str(DEFAULT_TIMEOUT_MS)))
+    except ValueError as exc:
+        raise ValueError("timeout must be an integer from 100 to 5000 milliseconds") from exc
+    if not 100 <= timeout_ms <= 5000:
+        raise ValueError("timeout must be an integer from 100 to 5000 milliseconds")
+
+    return endpoint, timeout_ms
+
+
+def _read_json_response(response: Any) -> dict[str, Any]:
+    payload = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise ValueError("response exceeded 65536 bytes")
+    decoded = json.loads(payload)
+    if not isinstance(decoded, dict):
+        raise ValueError("response was not a JSON object")
+    return decoded
+
+
+def evaluate(
+    hook_input: dict[str, Any],
+    env: dict[str, str],
+    *,
+    opener: Any = urlopen,
+) -> dict[str, Any]:
+    try:
+        failure_mode = _failure_mode(env)
+    except ValueError as exc:
+        return _failure(f"invalid adapter configuration ({exc})", "allow")
+    try:
+        endpoint, timeout_ms = _settings(env)
+    except ValueError as exc:
+        return _failure(f"invalid adapter configuration ({exc})", failure_mode)
+
+    if hook_input.get("hook_event_name") != "BeforeAgent":
+        return _failure("unexpected hook event", failure_mode)
+    prompt = hook_input.get("prompt")
+    if not isinstance(prompt, str):
+        return _failure("prompt was not a string", failure_mode)
+
+    request = Request(
+        endpoint,
+        data=json.dumps({"text": prompt}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with opener(request, timeout=timeout_ms / 1000) as response:
+            verdict = _read_json_response(response)
+    except (
+        HTTPError,
+        URLError,
+        TimeoutError,
+        OSError,
+        UnicodeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        return _failure(type(exc).__name__, failure_mode)
+
+    safe = verdict.get("safe")
+    degraded = verdict.get("degraded")
+    canary_status = verdict.get("canary_status")
+    if not isinstance(safe, bool) or not isinstance(degraded, bool) or not isinstance(canary_status, str):
+        return _failure("verdict omitted required coverage fields", failure_mode)
+    if not safe:
+        return _output("deny", "Little Canary rejected this prompt before the Gemini agent started.")
+    if degraded or canary_status != "exercised":
+        return _failure("behavioral coverage was not exercised", failure_mode)
+
+    advisory = verdict.get("advisory")
+    if isinstance(advisory, dict) and advisory.get("flagged") is True:
+        return _output(
+            "allow",
+            "Little Canary allowed this prompt with an advisory.",
+            system_message="Little Canary flagged this prompt but the server's routing policy allowed it.",
+        )
+    return _output("allow", "Little Canary allowed this prompt after exercised screening.")
+
+
+def main() -> int:
+    raw = sys.stdin.buffer.read(MAX_HOOK_INPUT_BYTES + 1)
+    failure_mode = os.environ.get("LITTLE_CANARY_FAILURE_MODE", "allow").strip().lower()
+    if failure_mode not in {"allow", "deny"}:
+        failure_mode = "allow"
+    if len(raw) > MAX_HOOK_INPUT_BYTES:
+        result = _failure("hook input exceeded 1048576 bytes", failure_mode)
+    else:
+        try:
+            hook_input = json.loads(raw)
+            if not isinstance(hook_input, dict):
+                raise ValueError("hook input was not a JSON object")
+            result = evaluate(hook_input, dict(os.environ))
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            result = _failure(str(exc), failure_mode)
+    sys.stdout.write(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gemini_extension.py
+++ b/tests/test_gemini_extension.py
@@ -6,13 +6,14 @@ import sys
 from io import BytesIO
 from pathlib import Path
 from urllib.error import URLError
+from urllib.request import ProxyHandler
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from little_canary_before_agent import evaluate  # noqa: E402
+from little_canary_before_agent import DIRECT_OPENER, evaluate  # noqa: E402
 
 
 class _Response:
@@ -36,6 +37,11 @@ class _RawResponse(_Response):
 
 def _input(prompt: str = "summarize this") -> dict[str, object]:
     return {"hook_event_name": "BeforeAgent", "prompt": prompt}
+
+
+def test_default_loopback_client_disables_environment_proxies() -> None:
+    proxy_handlers = [handler for handler in DIRECT_OPENER.handlers if isinstance(handler, ProxyHandler)]
+    assert proxy_handlers == []
 
 
 def _opener(verdict: dict[str, object]):
@@ -138,7 +144,11 @@ def test_command_protocol_emits_single_gemini_hook_json_object() -> None:
         input=json.dumps(_input()),
         text=True,
         capture_output=True,
-        env={"PATH": "/usr/bin:/bin", "LITTLE_CANARY_TIMEOUT_MS": "100"},
+        env={
+            "PATH": "/usr/bin:/bin",
+            "LITTLE_CANARY_ENDPOINT": "https://example.com/check",
+            "LITTLE_CANARY_TIMEOUT_MS": "100",
+        },
         check=True,
     )
     output = json.loads(proc.stdout)

--- a/tests/test_gemini_extension.py
+++ b/tests/test_gemini_extension.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from io import BytesIO
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from little_canary_before_agent import evaluate  # noqa: E402
+
+
+class _Response:
+    def __init__(self, body: dict[str, object]):
+        self._body = BytesIO(json.dumps(body).encode())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, size: int) -> bytes:
+        return self._body.read(size)
+
+
+class _RawResponse(_Response):
+    def __init__(self, body: bytes):
+        self._body = BytesIO(body)
+
+
+def _input(prompt: str = "summarize this") -> dict[str, object]:
+    return {"hook_event_name": "BeforeAgent", "prompt": prompt}
+
+
+def _opener(verdict: dict[str, object]):
+    def open_request(request, timeout):
+        assert request.full_url == "http://127.0.0.1:18421/check"
+        assert timeout == 3
+        assert json.loads(request.data) == {"text": _input()["prompt"]}
+        return _Response(verdict)
+
+    return open_request
+
+
+def test_exercised_safe_verdict_allows_agent() -> None:
+    result = evaluate(
+        _input(),
+        {},
+        opener=_opener({"safe": True, "degraded": False, "canary_status": "exercised"}),
+    )
+    assert result == {
+        "decision": "allow",
+        "reason": "Little Canary allowed this prompt after exercised screening.",
+    }
+
+
+def test_unsafe_verdict_denies_agent() -> None:
+    result = evaluate(
+        _input(),
+        {},
+        opener=_opener({"safe": False, "degraded": False, "canary_status": "exercised"}),
+    )
+    assert result["decision"] == "deny"
+    assert "before the Gemini agent started" in result["reason"]
+
+
+@pytest.mark.parametrize("failure_mode, expected", [("allow", "allow"), ("deny", "deny")])
+def test_degraded_coverage_obeys_explicit_failure_policy(failure_mode: str, expected: str) -> None:
+    result = evaluate(
+        _input(),
+        {"LITTLE_CANARY_FAILURE_MODE": failure_mode},
+        opener=_opener({"safe": True, "degraded": True, "canary_status": "failed"}),
+    )
+    assert result["decision"] == expected
+    assert "coverage was not exercised" in result["reason"]
+
+
+def test_transport_failure_is_bounded_and_fail_open_by_default() -> None:
+    def unavailable(_request, timeout):
+        assert timeout == 3
+        raise URLError("offline")
+
+    result = evaluate(_input(), {}, opener=unavailable)
+    assert result["decision"] == "allow"
+    assert "fail-open" in result["reason"]
+    assert "continued" in result["systemMessage"]
+
+
+def test_transport_failure_can_be_configured_fail_closed() -> None:
+    def unavailable(_request, timeout):
+        assert timeout == 3
+        raise URLError("offline")
+
+    result = evaluate(
+        _input(),
+        {"LITTLE_CANARY_FAILURE_MODE": "deny"},
+        opener=unavailable,
+    )
+    assert result["decision"] == "deny"
+    assert "configured fail-closed policy" in result["reason"]
+
+
+def test_non_loopback_endpoint_is_rejected_without_network_call() -> None:
+    result = evaluate(_input(), {"LITTLE_CANARY_ENDPOINT": "https://example.com/check"})
+    assert result["decision"] == "allow"
+    assert "invalid adapter configuration" in result["reason"]
+
+
+def test_invalid_endpoint_obeys_fail_closed_policy() -> None:
+    result = evaluate(
+        _input(),
+        {
+            "LITTLE_CANARY_ENDPOINT": "https://example.com/check",
+            "LITTLE_CANARY_FAILURE_MODE": "deny",
+        },
+    )
+    assert result["decision"] == "deny"
+
+
+@pytest.mark.parametrize("body", [b"not-json", b"x" * (64 * 1024 + 1)])
+def test_malformed_or_oversized_response_is_not_treated_as_pass(body: bytes) -> None:
+    result = evaluate(_input(), {}, opener=lambda *_args, **_kwargs: _RawResponse(body))
+    assert result["decision"] == "allow"
+    assert "screening unavailable" in result["reason"]
+    assert "exercised screening" not in result["reason"]
+
+
+def test_command_protocol_emits_single_gemini_hook_json_object() -> None:
+    hook = ROOT / "scripts" / "little_canary_before_agent.py"
+    proc = subprocess.run(
+        [sys.executable, str(hook)],
+        input=json.dumps(_input()),
+        text=True,
+        capture_output=True,
+        env={"PATH": "/usr/bin:/bin", "LITTLE_CANARY_TIMEOUT_MS": "100"},
+        check=True,
+    )
+    output = json.loads(proc.stdout)
+    assert output["decision"] == "allow"
+    assert output["reason"].endswith("configured fail-open policy.")
+    assert proc.stderr == ""


### PR DESCRIPTION
## Summary
- package Little Canary as a native Gemini CLI extension
- screen the exact prompt at BeforeAgent and deny before model execution on unsafe verdicts
- make degraded/unavailable coverage visibly fail-open by default with an opt-in fail-closed mode
- bound the loopback endpoint, timeout, and payload sizes

## Validation
- copied-install live unsafe run: deny with zero model tokens and zero tool calls
- copied-install live unavailable-server run: visible fail-open system message in Gemini CLI output
- Gemini CLI 0.32.1 native extension validation
- 358 tests, including 11 focused extension tests
- Ruff, compileall, and isolated Hermes Gate pass
- Roli Twin: SHIP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini CLI extension support for screening prompts with a local Little Canary server before agent runs.
  * Unsafe prompts can be blocked, while advisory results remain allowed with a system message.
  * Added configurable endpoint, timeout, and failure-mode settings.
  * Added setup and configuration guidance, including default behavior and limitations.

* **Tests**
  * Added coverage for safe and unsafe verdicts, degraded responses, failures, validation, malformed data, and oversized responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->