### PR TITLE
feat: add Claude Code UserPromptSubmit plugin gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "hermes-labs",
+  "description": "Hermes Labs plugins for Claude Code. Little Canary screens prompts for injection with a sacrificial canary model.",
+  "owner": {
+    "name": "Hermes Labs",
+    "email": "roli@hermes-labs.ai"
+  },
+  "plugins": [
+    {
+      "name": "little-canary",
+      "source": "./plugins/claude-code",
+      "description": "Blocks a Claude Code turn when a local Little Canary server rejects the submitted prompt.",
+      "category": "security",
+      "homepage": "https://littlecanary.ai"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -244,6 +244,61 @@ This extension blocks one Gemini agent run at its pre-agent boundary. It does
 not establish a general security guarantee or replace least privilege and tool
 policy.
 
+## Claude Code plugin
+
+This repository is also a Claude Code marketplace that serves one plugin. The
+plugin uses Claude Code's `UserPromptSubmit` hook to screen the exact submitted
+prompt before the turn starts and block it when Little Canary returns
+`safe: false`.
+
+The marketplace manifest lives at `.claude-plugin/marketplace.json`, where
+Claude Code discovers it. The plugin itself is the self-contained directory
+`plugins/claude-code/` (plugin manifest, hook registration, and the standalone
+adapter script). Claude Code copies only that directory into its plugin cache,
+so the Gemini CLI extension files at the repository root (`gemini-extension.json`,
+`hooks/hooks.json`) are never installed or loaded by Claude Code.
+
+Start the loopback server in blocking mode, then add this repository as a
+marketplace and install the plugin. This integration was verified with Claude
+Code 2.1.261:
+
+```bash
+little-canary serve --mode block
+claude plugin marketplace add hermes-labs-ai/little-canary
+claude plugin install little-canary@hermes-labs
+```
+
+To validate a source checkout, validate both manifests explicitly. Running
+`claude plugin validate .` from the repository root only validates the
+marketplace manifest, because the repository root is not itself a plugin:
+
+```bash
+claude plugin validate .claude-plugin/marketplace.json --strict
+claude plugin validate plugins/claude-code --strict
+```
+
+To install from a local checkout instead of GitHub, pass the checkout path to
+`claude plugin marketplace add` and then run the same install command.
+
+The hook calls only `http://127.0.0.1:18421/check` by default and completes its
+request within three seconds. It sends the prompt as the JSON body
+`{"text": ...}`. The loopback server rejects request bodies larger than 64 KiB
+(65,536 bytes) with HTTP `413`; that ceiling applies to the encoded JSON body,
+not to the prompt's character count, so non-ASCII text reaches it sooner. Such
+prompts are not screened at all. Transport errors, HTTP errors including that
+`413`, malformed responses, and unexercised behavioral coverage are visibly
+fail-open by default: the turn continues and Claude Code shows a warning such
+as `Little Canary screening unavailable: HTTPError`, so they are never reported
+as a clean pass. Set `LITTLE_CANARY_FAILURE_MODE=deny` in the Claude Code
+process environment to block the turn on every one of those failures instead.
+`LITTLE_CANARY_ENDPOINT` may select another loopback HTTP `/check` URL, and
+`LITTLE_CANARY_TIMEOUT_MS` may be set from 100 through 5000. The hook never
+writes model context; it emits exactly one JSON object per event.
+
+This plugin blocks one Claude Code turn at its prompt-submission boundary. It
+does not screen tool results, and it does not establish a general security
+guarantee or replace least privilege and tool policy.
+
 ## Evidence labels and limitations
 
 Behavioral evidence is labeled:

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "little-canary",
+  "version": "0.3.5",
+  "description": "Blocks a Claude Code turn when a local Little Canary server rejects the submitted prompt.",
+  "author": {
+    "name": "Hermes Labs",
+    "email": "roli@hermes-labs.ai"
+  },
+  "homepage": "https://littlecanary.ai",
+  "repository": "https://github.com/hermes-labs-ai/little-canary",
+  "license": "Apache-2.0",
+  "keywords": ["prompt-injection", "llm-security", "agent-security", "canary", "hooks"]
+}

--- a/plugins/claude-code/hooks/hooks.json
+++ b/plugins/claude-code/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Screen the exact submitted prompt with the local Little Canary server before Claude Code starts the turn.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/little_canary_user_prompt_submit.py\"",
+            "timeout": 7
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-code/scripts/little_canary_user_prompt_submit.py
+++ b/plugins/claude-code/scripts/little_canary_user_prompt_submit.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Claude Code UserPromptSubmit adapter for Little Canary's loopback HTTP server."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import ProxyHandler, Request, build_opener
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:18421/check"
+DEFAULT_TIMEOUT_MS = 3000
+MAX_HOOK_INPUT_BYTES = 1024 * 1024
+MAX_RESPONSE_BYTES = 64 * 1024
+DIRECT_OPENER = build_opener(ProxyHandler({}))
+
+
+def _block(reason: str) -> dict[str, Any]:
+    return {"decision": "block", "reason": reason}
+
+
+def _allow(*, system_message: str | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    if system_message:
+        result["systemMessage"] = system_message
+    return result
+
+
+def _failure(reason: str, failure_mode: str) -> dict[str, Any]:
+    message = f"Little Canary screening unavailable: {reason}."
+    if failure_mode == "deny":
+        return _block(f"{message} Prompt blocked by configured fail-closed policy.")
+    return _allow(system_message=f"{message} Claude Code continued because Little Canary is fail-open.")
+
+
+def _failure_mode(env: dict[str, str]) -> str:
+    failure_mode = env.get("LITTLE_CANARY_FAILURE_MODE", "allow").strip().lower()
+    if failure_mode not in {"allow", "deny"}:
+        raise ValueError("failure mode must be 'allow' or 'deny'")
+    return failure_mode
+
+
+def _settings(env: dict[str, str]) -> tuple[str, int]:
+    endpoint = env.get("LITTLE_CANARY_ENDPOINT", DEFAULT_ENDPOINT)
+    parsed = urlsplit(endpoint)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.path != "/check"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("endpoint must be an HTTP loopback /check URL without credentials or query data")
+
+    try:
+        timeout_ms = int(env.get("LITTLE_CANARY_TIMEOUT_MS", str(DEFAULT_TIMEOUT_MS)))
+    except ValueError as exc:
+        raise ValueError("timeout must be an integer from 100 to 5000 milliseconds") from exc
+    if not 100 <= timeout_ms <= 5000:
+        raise ValueError("timeout must be an integer from 100 to 5000 milliseconds")
+
+    return endpoint, timeout_ms
+
+
+def _read_json_response(response: Any) -> dict[str, Any]:
+    payload = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise ValueError("response exceeded 65536 bytes")
+    decoded = json.loads(payload)
+    if not isinstance(decoded, dict):
+        raise ValueError("response was not a JSON object")
+    return decoded
+
+
+def evaluate(
+    hook_input: dict[str, Any],
+    env: dict[str, str],
+    *,
+    opener: Any = DIRECT_OPENER.open,
+) -> dict[str, Any]:
+    """Return the Claude Code hook JSON object for one UserPromptSubmit event."""
+    try:
+        failure_mode = _failure_mode(env)
+    except ValueError as exc:
+        return _failure(f"invalid adapter configuration ({exc})", "allow")
+    try:
+        endpoint, timeout_ms = _settings(env)
+    except ValueError as exc:
+        return _failure(f"invalid adapter configuration ({exc})", failure_mode)
+
+    if hook_input.get("hook_event_name") != "UserPromptSubmit":
+        return _failure("unexpected hook event", failure_mode)
+    prompt = hook_input.get("prompt")
+    if not isinstance(prompt, str):
+        return _failure("prompt was not a string", failure_mode)
+
+    request = Request(
+        endpoint,
+        data=json.dumps({"text": prompt}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with opener(request, timeout=timeout_ms / 1000) as response:
+            verdict = _read_json_response(response)
+    except (
+        HTTPError,
+        URLError,
+        TimeoutError,
+        OSError,
+        UnicodeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        return _failure(type(exc).__name__, failure_mode)
+
+    safe = verdict.get("safe")
+    degraded = verdict.get("degraded")
+    canary_status = verdict.get("canary_status")
+    if not isinstance(safe, bool) or not isinstance(degraded, bool) or not isinstance(canary_status, str):
+        return _failure("verdict omitted required coverage fields", failure_mode)
+    if not safe:
+        return _block("Little Canary rejected this prompt before Claude Code started the turn.")
+    if degraded or canary_status != "exercised":
+        return _failure("behavioral coverage was not exercised", failure_mode)
+
+    advisory = verdict.get("advisory")
+    if isinstance(advisory, dict) and advisory.get("flagged") is True:
+        return _allow(system_message="Little Canary flagged this prompt but the server's routing policy allowed it.")
+    return _allow()
+
+
+def main() -> int:
+    raw = sys.stdin.buffer.read(MAX_HOOK_INPUT_BYTES + 1)
+    env = dict(os.environ)
+    try:
+        failure_mode = _failure_mode(env)
+    except ValueError as exc:
+        result = _failure(f"invalid adapter configuration ({exc})", "allow")
+    else:
+        if len(raw) > MAX_HOOK_INPUT_BYTES:
+            result = _failure("hook input exceeded 1048576 bytes", failure_mode)
+        else:
+            try:
+                hook_input = json.loads(raw)
+                if not isinstance(hook_input, dict):
+                    raise ValueError("hook input was not a JSON object")
+                result = evaluate(hook_input, env)
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+                result = _failure(str(exc), failure_mode)
+    # Claude Code treats non-JSON stdout as model context; always emit exactly one JSON object.
+    sys.stdout.write(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_claude_code_plugin.py
+++ b/tests/test_claude_code_plugin.py
@@ -1,0 +1,293 @@
+"""Claude Code plugin packaging and UserPromptSubmit adapter tests (offline)."""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from io import BytesIO
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import ProxyHandler
+
+import pytest
+
+from little_canary import __version__
+from little_canary.server import MAX_REQUEST_BYTES
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE_FILE = ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_ROOT = ROOT / "plugins" / "claude-code"
+PLUGIN_MANIFEST = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+HOOKS_FILE = PLUGIN_ROOT / "hooks" / "hooks.json"
+HOOK_SCRIPT = PLUGIN_ROOT / "scripts" / "little_canary_user_prompt_submit.py"
+sys.path.insert(0, str(HOOK_SCRIPT.parent))
+
+from little_canary_user_prompt_submit import DIRECT_OPENER, evaluate  # noqa: E402
+
+
+class _Response:
+    def __init__(self, body: dict[str, object]):
+        self._body = BytesIO(json.dumps(body).encode())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, size: int) -> bytes:
+        return self._body.read(size)
+
+
+class _RawResponse(_Response):
+    def __init__(self, body: bytes):
+        self._body = BytesIO(body)
+
+
+def _input(prompt: str = "summarize this") -> dict[str, object]:
+    return {"hook_event_name": "UserPromptSubmit", "prompt": prompt, "source": "user"}
+
+
+def _opener(verdict: dict[str, object]):
+    def open_request(request, timeout):
+        assert request.full_url == "http://127.0.0.1:18421/check"
+        assert timeout == 3
+        assert json.loads(request.data) == {"text": _input()["prompt"]}
+        return _Response(verdict)
+
+    return open_request
+
+
+def _exercised(safe: bool, **extra: object) -> dict[str, object]:
+    verdict: dict[str, object] = {"safe": safe, "degraded": False, "canary_status": "exercised"}
+    verdict.update(extra)
+    return verdict
+
+
+# --- packaging ---------------------------------------------------------------
+
+
+def test_marketplace_points_at_the_self_contained_plugin_directory() -> None:
+    marketplace = json.loads(MARKETPLACE_FILE.read_text())
+    (entry,) = marketplace["plugins"]
+    assert entry["name"] == "little-canary"
+    assert entry["source"] == "./plugins/claude-code"
+    # Relative sources resolve against the marketplace root (the repository), not .claude-plugin/.
+    assert (ROOT / entry["source"]).resolve() == PLUGIN_ROOT
+    assert PLUGIN_MANIFEST.is_file()
+
+
+def test_repository_root_is_a_marketplace_but_not_a_plugin() -> None:
+    # Only the marketplace manifest lives at the repository root. Without a root plugin.json,
+    # Claude Code never treats the repository itself as a plugin, so the Gemini CLI files
+    # (hooks/hooks.json, gemini-extension.json) are never scanned or copied on install.
+    assert sorted(path.name for path in (ROOT / ".claude-plugin").iterdir()) == ["marketplace.json"]
+    gemini_hooks = ROOT / "hooks" / "hooks.json"
+    assert PLUGIN_ROOT not in gemini_hooks.parents
+    assert list(json.loads(gemini_hooks.read_text())["hooks"]) == ["BeforeAgent"]
+
+
+def test_plugin_manifest_tracks_package_identity() -> None:
+    manifest = json.loads(PLUGIN_MANIFEST.read_text())
+    assert manifest["name"] == json.loads(MARKETPLACE_FILE.read_text())["plugins"][0]["name"]
+    assert manifest["version"] == __version__
+    assert manifest["repository"] == "https://github.com/hermes-labs-ai/little-canary"
+    # Claude Code loads hooks/hooks.json from the plugin root automatically and refuses to load a
+    # plugin whose manifest "hooks" field names that same file again ("Duplicate hooks file").
+    assert "hooks" not in manifest
+    assert HOOKS_FILE == PLUGIN_ROOT / "hooks" / "hooks.json"
+
+
+def test_plugin_hooks_register_only_the_prompt_gate_with_a_bounded_timeout() -> None:
+    hooks = json.loads(HOOKS_FILE.read_text())["hooks"]
+    assert list(hooks) == ["UserPromptSubmit"]
+    (matcher,) = hooks["UserPromptSubmit"]
+    (hook,) = matcher["hooks"]
+    assert hook["type"] == "command"
+    assert hook["command"] == 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/little_canary_user_prompt_submit.py"'
+    assert HOOK_SCRIPT.is_file()
+    assert 5 <= hook["timeout"] <= 10  # seconds; must exceed the adapter's 5000 ms ceiling
+
+
+def test_plugin_directory_is_self_contained() -> None:
+    # Claude Code copies only the plugin directory into its cache, so every file the hook
+    # needs must live under plugins/claude-code and must not reach above it.
+    expected = {
+        PLUGIN_ROOT / ".claude-plugin" / "plugin.json",
+        HOOKS_FILE,
+        HOOK_SCRIPT,
+    }
+    actual = {path for path in PLUGIN_ROOT.rglob("*") if path.is_file() and "__pycache__" not in path.parts}
+    assert actual == expected
+    for path in (PLUGIN_MANIFEST, HOOKS_FILE):
+        assert ".." not in path.read_text()
+
+
+def test_hook_script_depends_only_on_the_standard_library() -> None:
+    # The cached plugin has no access to this repository or to little_canary's dependencies.
+    tree = ast.parse(HOOK_SCRIPT.read_text())
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+    assert imported <= {"__future__", "json", "os", "sys", "typing", "urllib"}
+
+
+# --- adapter -----------------------------------------------------------------
+
+
+def test_default_loopback_client_disables_environment_proxies() -> None:
+    proxy_handlers = [handler for handler in DIRECT_OPENER.handlers if isinstance(handler, ProxyHandler)]
+    assert proxy_handlers == []
+
+
+def test_exercised_safe_verdict_emits_no_decision() -> None:
+    assert evaluate(_input(), {}, opener=_opener(_exercised(True))) == {}
+
+
+def test_unsafe_verdict_blocks_prompt() -> None:
+    result = evaluate(_input(), {}, opener=_opener(_exercised(False)))
+    assert result["decision"] == "block"
+    assert "before Claude Code started the turn" in result["reason"]
+
+
+def test_flagged_but_allowed_verdict_is_visible_to_user_without_blocking() -> None:
+    result = evaluate(_input(), {}, opener=_opener(_exercised(True, advisory={"flagged": True})))
+    assert "decision" not in result
+    assert "flagged this prompt" in result["systemMessage"]
+
+
+@pytest.mark.parametrize("failure_mode, blocked", [("allow", False), ("deny", True)])
+def test_degraded_coverage_obeys_explicit_failure_policy(failure_mode: str, blocked: bool) -> None:
+    result = evaluate(
+        _input(),
+        {"LITTLE_CANARY_FAILURE_MODE": failure_mode},
+        opener=_opener({"safe": True, "degraded": True, "canary_status": "failed"}),
+    )
+    assert (result.get("decision") == "block") is blocked
+    text = result["reason"] if blocked else result["systemMessage"]
+    assert "behavioral coverage was not exercised" in text
+
+
+def test_transport_failure_is_bounded_and_fail_open_by_default() -> None:
+    def open_request(_request, timeout):
+        assert timeout == 3
+        raise URLError("connection refused")
+
+    result = evaluate(_input(), {}, opener=open_request)
+    assert "decision" not in result
+    assert result["systemMessage"].startswith("Little Canary screening unavailable: URLError.")
+    assert "fail-open" in result["systemMessage"]
+
+
+def test_transport_failure_can_be_configured_fail_closed() -> None:
+    def open_request(_request, timeout):
+        raise URLError("connection refused")
+
+    result = evaluate(_input(), {}, opener=open_request)  # default policy is allow
+    assert "decision" not in result
+    result = evaluate(_input(), {"LITTLE_CANARY_FAILURE_MODE": "deny"}, opener=open_request)
+    assert result == {
+        "decision": "block",
+        "reason": "Little Canary screening unavailable: URLError. Prompt blocked by configured fail-closed policy.",
+    }
+
+
+@pytest.mark.parametrize("failure_mode, blocked", [("allow", False), ("deny", True)])
+def test_server_request_ceiling_rejection_follows_failure_policy(failure_mode: str, blocked: bool) -> None:
+    # The loopback server refuses JSON bodies above MAX_REQUEST_BYTES with HTTP 413. Such prompts
+    # are never screened; the adapter reports the rejection under the configured failure policy.
+    assert MAX_REQUEST_BYTES == 64 * 1024
+    oversized = "a" * MAX_REQUEST_BYTES
+
+    def open_request(request, timeout):
+        assert len(request.data) > MAX_REQUEST_BYTES
+        raise HTTPError(request.full_url, 413, "Payload Too Large", None, BytesIO(b"{}"))  # type: ignore[arg-type]
+
+    result = evaluate(_input(oversized), {"LITTLE_CANARY_FAILURE_MODE": failure_mode}, opener=open_request)
+    assert (result.get("decision") == "block") is blocked
+    text = result["reason"] if blocked else result["systemMessage"]
+    assert text.startswith("Little Canary screening unavailable: HTTPError.")
+
+
+def test_non_loopback_endpoint_is_rejected_without_network_call() -> None:
+    def open_request(_request, timeout):
+        raise AssertionError("network call must not happen")
+
+    result = evaluate(_input(), {"LITTLE_CANARY_ENDPOINT": "https://example.com/check"}, opener=open_request)
+    assert "decision" not in result
+    assert "invalid adapter configuration" in result["systemMessage"]
+
+
+def test_unexpected_hook_event_obeys_failure_policy() -> None:
+    def open_request(_request, timeout):
+        raise AssertionError("network call must not happen")
+
+    result = evaluate(
+        {"hook_event_name": "PreToolUse", "prompt": "x"},
+        {"LITTLE_CANARY_FAILURE_MODE": "deny"},
+        opener=open_request,
+    )
+    assert result["decision"] == "block"
+    assert "unexpected hook event" in result["reason"]
+
+
+@pytest.mark.parametrize("body", [b"[]", b"not json", b"{" + b" " * 70000 + b"}"])
+def test_malformed_or_oversized_response_is_not_treated_as_pass(body: bytes) -> None:
+    def open_request(_request, timeout):
+        return _RawResponse(body)
+
+    result = evaluate(_input(), {"LITTLE_CANARY_FAILURE_MODE": "deny"}, opener=open_request)
+    assert result["decision"] == "block"
+
+
+def test_command_protocol_emits_single_claude_hook_json_object() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(_input()),
+        text=True,
+        capture_output=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "LITTLE_CANARY_ENDPOINT": "https://example.com/check",
+            "LITTLE_CANARY_TIMEOUT_MS": "100",
+        },
+        check=True,
+    )
+    output = json.loads(proc.stdout)
+    assert "decision" not in output
+    assert output["systemMessage"].endswith("Claude Code continued because Little Canary is fail-open.")
+    assert proc.stderr == ""
+
+
+def test_command_protocol_never_emits_bare_text_on_malformed_input() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="not json",
+        text=True,
+        capture_output=True,
+        env={"PATH": "/usr/bin:/bin", "LITTLE_CANARY_FAILURE_MODE": "deny"},
+        check=True,
+    )
+    output = json.loads(proc.stdout)
+    assert output["decision"] == "block"
+    assert proc.stderr == ""
+
+
+def test_command_protocol_reports_invalid_failure_mode_instead_of_coercing_it() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="not json",
+        text=True,
+        capture_output=True,
+        env={"PATH": "/usr/bin:/bin", "LITTLE_CANARY_FAILURE_MODE": "bogus"},
+        check=True,
+    )
+    output = json.loads(proc.stdout)
+    assert "decision" not in output
+    assert "invalid adapter configuration (failure mode must be 'allow' or 'deny')" in output["systemMessage"]
+    assert proc.stderr == ""


### PR DESCRIPTION
## What changes

- add a Claude Code `UserPromptSubmit` plugin that sends the submitted prompt to a local Little Canary `/check` endpoint before the turn starts
- block the turn when the server returns `safe: false`
- visibly fail open on transport, configuration, malformed-response, or unexercised-coverage failures; support explicit fail-closed operation with `LITTLE_CANARY_FAILURE_MODE=deny`
- package the plugin in a self-contained marketplace subdirectory so installs do not include the repository or load the Gemini hook manifest
- document install, configuration, scope, and the 64 KiB server request ceiling

## Verification

- full offline suite: 386 passed
- ruff check passed; changed Python files pass format checks
- standalone adapter passes mypy and Python 3.9 syntax parsing
- root marketplace and nested plugin manifests both pass Claude Code 2.1.261 validation
- isolated marketplace install succeeded and cached only the plugin manifest, hook, and adapter
- bounded local live run with `qwen2.5:1.5b`: an injection prompt was blocked before a Claude turn (`num_turns: 0`, `duration_api_ms: 0`, `total_cost_usd: 0`); a benign prompt was allowed to continue
- fail-open and opt-in fail-closed outage behavior were reproduced locally

## Evidence boundary

The live result is a bounded local observation for the exact runtime, model, prompt, and configuration tested. This integration does not claim general prompt-injection prevention and does not screen tool results.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code marketplace and Little Canary security plugin.
  * Screens submitted prompts before each Claude Code turn and can block unsafe prompts.
  * Supports configurable endpoints, timeouts, and fail-open or fail-closed behavior.
  * Displays warnings when screening is unavailable or coverage is degraded.

* **Documentation**
  * Added setup, validation, configuration, and hook behavior documentation to the README.

* **Tests**
  * Added coverage for plugin packaging, prompt screening, failure handling, configuration validation, and hook output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->