### PR TITLE
chore: adopt organization repository standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,17 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/hermes-quality.yml
+++ b/.github/workflows/hermes-quality.yml
@@ -9,15 +9,6 @@ permissions:
 
 jobs:
   full:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: '3.12'
-      - name: Install project and declared gate tools
-        run: python3 -m pip install -e '.[dev]'
-      - name: Run declared full gate
-        run: python3 .hermes/hermes_gate_runner.py full
+    uses: hermes-labs-ai/.github/.github/workflows/reusable-hermes-quality.yml@main
+    with:
+      install-command: python3 -m pip install -e '.[dev]'

--- a/.github/workflows/lintlang.yml
+++ b/.github/workflows/lintlang.yml
@@ -11,20 +11,6 @@ permissions:
 
 jobs:
   language-contract:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Scan agent instructions
-        uses: hermes-labs-ai/lintlang@f89c3b0b8986fad162859dca052a8d5fe227eede # v0.5.3
-        with:
-          path: "AGENTS.md"
-          fail-on: fail
-          sarif-file: lintlang.sarif
-
-      - name: Upload SARIF
-        if: always() && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
-        with:
-          sarif_file: lintlang.sarif
+    uses: hermes-labs-ai/.github/.github/workflows/reusable-lintlang.yml@main
+    with:
+      path: "AGENTS.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+<!-- Instruction contract v1.0 — 2026-09-09 -->
+
+Priority order: preserve security and coverage semantics; preserve public API behavior;
+then minimize the diff. Treat each user request as an independent task and carry prior
+task state forward only when the user explicitly asks.
+
 Little Canary is a prompt-injection detection library that uses a sacrificial canary model as an inbound risk sensor.
 
 ## Use it for
@@ -14,6 +20,13 @@ Little Canary is a prompt-injection detection library that uses a sacrificial ca
 - audited benchmark comparisons
 - replacing runtime containment or outbound tool controls
 
+## Key paths
+
+- `little_canary/` — package source
+- `tests/` — pytest suite
+- `benchmarks/` — false-positive/red-team runners, not part of the default CLI flow
+- `.hermes/` — declared quality-gate config run by CI's Hermes quality rail
+
 ## Minimal commands
 
 ```bash
@@ -25,6 +38,7 @@ little-canary serve --help
 pytest -q
 ruff check little_canary tests
 mypy little_canary
+python -m build
 ```
 
 ## Output shape
@@ -55,6 +69,13 @@ mypy little_canary
 - never treat replay, mock, or static evidence as a current live-model result
 - keep benchmark caveats aligned with README claims
 - keep tests offline and mock network calls
+
+## Definition of done
+
+- `pytest -q` and `ruff check little_canary tests` pass; `mypy little_canary` is diagnostic
+- new behavior has an offline, mocked-network test
+- fail-open behavior and coverage-state semantics are unchanged unless explicitly intended
+- README and this file stay consistent with observed CLI/API behavior
 
 ## Optional Hermeneutic Gate
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # little-canary
 
+[![CI](https://github.com/hermes-labs-ai/little-canary/actions/workflows/ci.yml/badge.svg)](https://github.com/hermes-labs-ai/little-canary/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/little-canary)](https://pypi.org/project/little-canary/)
+[![Python](https://img.shields.io/pypi/pyversions/little-canary)](https://pypi.org/project/little-canary/)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-2ea44f)](LICENSE)
+
 Prompt-injection sensing through a powerless sacrificial model.
 
 **Links:** [Website](https://littlecanary.ai) · [Hermes Labs product page](https://hermes-labs.ai/little-canary)


### PR DESCRIPTION
Adopts the Hermes Labs organization defaults by reference, adds/updates the concise repository-specific AGENTS.md contract, groups weekly Dependabot updates, and keeps specialized CI/release behavior local. Product code is unchanged.\n\nValidation: actionlint + YAML parse; repository lint/test/build commands; LintLang AGENTS.md scan. The reusable organization workflows were merged first in hermes-labs-ai/.github#18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency update requests are now grouped by ecosystem, reducing the number of separate maintenance requests.
  * Quality and language-contract checks now use standardized reusable workflows.

* **Documentation**
  * Added project guidance covering key paths, build commands, completion criteria, and quality checks.
  * Added status, package version, supported Python version, and license badges to the project overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->