### PR TITLE
ci: enable OpenSSF Scorecard supply-chain security workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,64 @@
+# This workflow uses actions that are not certified by GitHub. They are
+# provided by a third-party (OpenSSF) and are governed by separate terms of
+# service, privacy policy, and support documentation. See
+# https://github.com/ossf/scorecard-action.
+#
+# Scorecard produces a heuristic supply-chain risk signal, not a security
+# certification: it flags process gaps (branch protection, pinning,
+# maintenance activity) using static, automatable checks, and a high score is
+# not proof of the absence of vulnerabilities.
+name: Scorecard supply-chain security
+
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '21 5 * * 2'
+  push:
+    branches: [main]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # `publish_results: true` only works when run from the default branch.
+    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes results to the OpenSSF REST API and enables the badge.
+          # Do not enable a badge in README.md until the first scheduled
+          # run on the default branch has completed successfully.
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@faaca9a8f6edddba5725ffe5adefdab6669a2eca # v3.38.0
+        with:
+          sarif_file: results.sarif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "openai-agents>=0.22.0; python_version >= '3.10'",
     "pytest>=8.4.2",
     "pytest-cov>=7.1.0",
+    "pyyaml>=6.0.2",
     "mypy>=1.19.1,<3",
     "ruff>=0.15.22",
     "pip-audit>=2.10.1; python_version >= '3.10'",

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -142,3 +142,18 @@ def test_dependabot_merge_waits_for_required_checks_without_repository_auto_merg
     assert workflow.index(wait) < workflow.index(merge)
     assert "gh pr merge --auto" not in workflow
     assert "HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in workflow
+
+
+def test_scorecard_workflow_pins_actions_and_narrows_permissions():
+    workflow = _read(".github/workflows/scorecard.yml")
+
+    for uses in re.findall(r"uses: (\S+)", workflow):
+        action, _, ref = uses.partition("@")
+        assert re.fullmatch(r"[0-9a-f]{40}", ref), f"{action} is not pinned to a full commit SHA"
+
+    assert "permissions: read-all" in workflow
+    assert "      security-events: write\n" in workflow
+    assert "      id-token: write\n" in workflow
+    assert "cron:" in workflow
+    assert "branch_protection_rule:" in workflow
+    assert "branches: [main]" in workflow

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -4,6 +4,8 @@ import json
 import re
 from pathlib import Path
 
+import yaml
+
 from little_canary import __version__
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -145,15 +147,25 @@ def test_dependabot_merge_waits_for_required_checks_without_repository_auto_merg
 
 
 def test_scorecard_workflow_pins_actions_and_narrows_permissions():
-    workflow = _read(".github/workflows/scorecard.yml")
+    # Parse the executable document: comments and unrelated nodes must not be
+    # able to satisfy the security contract asserted below.
+    workflow = yaml.safe_load(_read(".github/workflows/scorecard.yml"))
+    # PyYAML reads the bare ``on`` key as the YAML 1.1 boolean ``True``.
+    triggers = workflow.get("on", workflow.get(True))
+    analysis = workflow["jobs"]["analysis"]
 
-    for uses in re.findall(r"uses: (\S+)", workflow):
-        action, _, ref = uses.partition("@")
+    assert "branch_protection_rule" in triggers
+    assert triggers["push"] == {"branches": ["main"]}
+    assert triggers["schedule"], "scorecard workflow has no schedule trigger"
+    for entry in triggers["schedule"]:
+        assert re.fullmatch(r"(\S+ ){4}\S+", entry["cron"]), entry
+
+    assert workflow["permissions"] == "read-all"
+    assert analysis["permissions"] == {"security-events": "write", "id-token": "write"}
+
+    pinned = {}
+    for step in analysis["steps"]:
+        action, _, ref = step["uses"].partition("@")
         assert re.fullmatch(r"[0-9a-f]{40}", ref), f"{action} is not pinned to a full commit SHA"
-
-    assert "permissions: read-all" in workflow
-    assert "      security-events: write\n" in workflow
-    assert "      id-token: write\n" in workflow
-    assert "cron:" in workflow
-    assert "branch_protection_rule:" in workflow
-    assert "branches: [main]" in workflow
+        pinned[action] = ref
+    assert {"ossf/scorecard-action", "github/codeql-action/upload-sarif"} <= pinned.keys()


### PR DESCRIPTION
## Summary
- Adds the current `actions/starter-workflows` OpenSSF Scorecard workflow (`.github/workflows/scorecard.yml`), resolved to this repo's default branch (`main`) and a weekly schedule trigger, alongside `branch_protection_rule` and `push: [main]` triggers per upstream guidance.
- Pins every action to a verified full commit SHA with a version comment, reusing this repo's already-pinned `actions/checkout@v7.0.1` and `actions/upload-artifact@v7.0.1` SHAs for consistency, and resolving fresh SHAs for `ossf/scorecard-action@v2.4.4` and `github/codeql-action/upload-sarif@v3.38.0`.
- Permissions follow upstream's documented model: `read-all` by default, narrowed at the job level to `security-events: write` and `id-token: write` (needed to upload SARIF to code scanning and to publish results / enable the badge).
- Adds a small repository-native test (`tests/test_release_metadata.py`) asserting every action is pinned to a 40-hex-char commit SHA and that the permissions/trigger shape is present — following this file's existing pattern of asserting on workflow YAML content (e.g. the `publish.yml` and `dependabot-auto-merge.yml` checks already there).
- **No README badge is added.** Per the task's own guidance, a badge should only go in after a first successful Scorecard run on `main` publishes results — otherwise it would render broken/empty.
- **Note on what Scorecard is:** OpenSSF Scorecard is a heuristic supply-chain risk signal (checks process hygiene like pinning, branch protection, maintenance activity) — it is not a security certification and a high score is not proof of the absence of vulnerabilities. This is called out directly in the workflow's header comment.

## Test plan
- [x] `actionlint .github/workflows/scorecard.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"` — parses
- [x] `ruff check little_canary/ tests/` — all checks passed
- [x] `pytest` — 424 passed, 1 skipped (full suite, including the new test)
- [x] `hermes-gate fast` — PASS
- [x] `hermes-gate review` (CodeRabbit) — PASS (one suppressed style nit: a missing `-> None` annotation, which matches this test file's existing convention of no return-type annotations elsewhere)
- [ ] First scheduled/push run on `main` after merge (will confirm Scorecard executes cleanly before any badge is added in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added automated repository security analysis that runs weekly, on updates to the main branch, and when branch protection changes.
  - Security checks use restricted permissions and submit results to code scanning.

- **Tests**
  - Added validation to ensure the security workflow uses pinned actions, scheduled execution, branch protection triggers, and appropriately scoped permissions.
  - Added supporting validation for the workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->