### PR TITLE
ci: archive releases to Software Heritage

### DIFF
--- a/.github/workflows/swh-archive.yml
+++ b/.github/workflows/swh-archive.yml
@@ -1,0 +1,19 @@
+name: Archive to Software Heritage
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Request Save Code Now archival
+        run: |
+          curl --fail --silent --show-error \
+            --request POST \
+            "https://archive.softwareheritage.org/api/1/origin/save/git/url/https://github.com/${GITHUB_REPOSITORY}/"
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/swh-archive.yml
+++ b/.github/workflows/swh-archive.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Request Save Code Now archival
         run: |
           curl --fail --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 60 \
             --request POST \
             "https://archive.softwareheritage.org/api/1/origin/save/git/url/https://github.com/${GITHUB_REPOSITORY}/"
         env:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/swh-archive.yml`, a release-triggered workflow that requests a Software Heritage Save Code Now archival on every published release.
- Reuses the exact 19-line workflow already merged to `main` in `hermes-labs-ai/agent-trash-guard`, `hermes-labs-ai/rule-audit`, and `hermes-labs-ai/agent-signage` (byte-identical diff verified against all three).
- No badges, claims, or Scorecard files touched.

## Context
- Inspected `main` and all open PRs first; PR #72 (Scorecard) is unrelated (adds `scorecard.yml` + `pyproject.toml`/test changes) and no equivalent SWH workflow exists anywhere in this repo.

## Test plan
- [x] YAML parse (`yaml.safe_load`) — OK
- [x] `actionlint .github/workflows/swh-archive.yml` — clean, exit 0
- [x] Full test suite: `pytest` — 429 passed
- [x] `hermes-gate fast` — PASS
- [x] Review: configured provider (CodeRabbit) returned `rate_limit` (quota exhausted); substituted one direct exact-diff review per task instructions — no blocking findings (least-privilege `permissions: contents: read`, `release:published` trigger only, repo name passed via `env:` not interpolated into the shell script, no secrets/checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- hermes-labs:attribution v1 -->
This contribution was produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Published releases are automatically submitted to Software Heritage for archival.
  * Archival requests run after release publication, supporting long-term access to released source code.
  * Requests now use connection and transfer timeouts to avoid waiting indefinitely when archival services are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->