### PR TITLE
fix(hermes-agent): preserve BLOCK tool authority and unambiguous turn keys

### DIFF
--- a/little_canary/hermes_agent_plugin.py
+++ b/little_canary/hermes_agent_plugin.py
@@ -1,4 +1,48 @@
-"""Optional Little Canary hooks for Hermes Agent."""
+"""
+hermes_agent_plugin.py - Optional Hermes Agent plugin integration
+
+Screens the user message of a Hermes Agent turn through Little Canary's
+existing :class:`~little_canary.pipeline.SecurityPipeline` exactly once, then
+lets the resulting disposition govern tool authority for the rest of that turn.
+
+Verified against the upstream framework
+-----------------------------------------
+Built against ``hermes-agent`` 0.19.0 (Nous Research, MIT), the published PyPI
+distribution. The relevant contract, read from that distribution's
+``hermes_cli/plugins.py`` and ``agent/turn_context.py``:
+
+* Discovery: ``ENTRY_POINTS_GROUP = "hermes_agent.plugins"``. The loader calls
+  ``ep.load()`` and then ``getattr(module, "register", None)``, so the entry
+  point must resolve to a **module** exposing ``register(ctx)`` -- not to the
+  ``register`` function itself. Entry-point plugins stay opt-in behind the
+  host's ``plugins.enabled`` allow-list.
+* ``pre_llm_call`` is called with ``session_id``, ``task_id``, ``turn_id``,
+  ``user_message``, ``conversation_history``, ``is_first_turn``, ``model``,
+  ``platform`` and ``sender_id``. A callback may return ``{"context": "..."}``
+  (or a plain string). That text is appended to the **user message** for the
+  current turn only. It **cannot stop the prompt from reaching the model** --
+  the hook has no deny channel at all.
+* ``pre_tool_call`` is called with ``tool_name``, ``args``, ``session_id``,
+  ``turn_id`` and related ids. Returning
+  ``{"action": "block", "message": "..."}`` genuinely vetoes the tool call:
+  ``resolve_pre_tool_block()`` hands the message back as the tool result the
+  model sees, and the tool never executes. A block directive without a
+  non-empty message is ignored by the host, so one is always supplied.
+
+What this plugin does and does not claim
+----------------------------------------
+It **does**: screen the turn's user message once, annotate the turn with a
+bounded note when the screening is FLAG / BLOCK / DEGRADED, and block
+downstream tool calls for a turn whose screening returned a genuine BLOCK.
+
+It **does not**: block prompt delivery, edit the system prompt, re-score on
+every tool call, or emit the raw user text or internal probe transcript into
+the model's context.
+
+Fail-open, like the rest of Little Canary: a pipeline exception, an
+unavailable Ollama backend, a missing turn key or an expired record all allow
+the turn and its tools to proceed. Only a genuine BLOCK verdict blocks.
+"""
 
 from __future__ import annotations
 
@@ -188,8 +232,8 @@ def session_prefix(session_id: str) -> str:
     :meth:`TurnDispositionStore.discard_session` matches on it, so the two can
     never drift into different encodings.
     """
-    session = (session_id or "").strip()
-    if not session:
+    session = session_id or ""
+    if not session.strip():
         return ""
     return f"{len(session)}:{session}{KEY_SEPARATOR}"
 
@@ -212,8 +256,8 @@ def turn_key(session_id: str, turn_id: str) -> str:
     pair -- ``("a::b", "c")`` and ``("a", "b::c")`` produce different keys.
     """
     prefix = session_prefix(session_id)
-    turn = (turn_id or "").strip()
-    if not prefix or not turn:
+    turn = turn_id or ""
+    if not prefix or not turn.strip():
         return ""
     return f"{prefix}{turn}"
 

--- a/little_canary/hermes_agent_plugin.py
+++ b/little_canary/hermes_agent_plugin.py
@@ -1,48 +1,4 @@
-"""
-hermes_agent_plugin.py - Optional Hermes Agent plugin integration
-
-Screens the user message of a Hermes Agent turn through Little Canary's
-existing :class:`~little_canary.pipeline.SecurityPipeline` exactly once, then
-lets the resulting disposition govern tool authority for the rest of that turn.
-
-Verified against the upstream framework
------------------------------------------
-Built against ``hermes-agent`` 0.19.0 (Nous Research, MIT), the published PyPI
-distribution. The relevant contract, read from that distribution's
-``hermes_cli/plugins.py`` and ``agent/turn_context.py``:
-
-* Discovery: ``ENTRY_POINTS_GROUP = "hermes_agent.plugins"``. The loader calls
-  ``ep.load()`` and then ``getattr(module, "register", None)``, so the entry
-  point must resolve to a **module** exposing ``register(ctx)`` -- not to the
-  ``register`` function itself. Entry-point plugins stay opt-in behind the
-  host's ``plugins.enabled`` allow-list.
-* ``pre_llm_call`` is called with ``session_id``, ``task_id``, ``turn_id``,
-  ``user_message``, ``conversation_history``, ``is_first_turn``, ``model``,
-  ``platform`` and ``sender_id``. A callback may return ``{"context": "..."}``
-  (or a plain string). That text is appended to the **user message** for the
-  current turn only. It **cannot stop the prompt from reaching the model** --
-  the hook has no deny channel at all.
-* ``pre_tool_call`` is called with ``tool_name``, ``args``, ``session_id``,
-  ``turn_id`` and related ids. Returning
-  ``{"action": "block", "message": "..."}`` genuinely vetoes the tool call:
-  ``resolve_pre_tool_block()`` hands the message back as the tool result the
-  model sees, and the tool never executes. A block directive without a
-  non-empty message is ignored by the host, so one is always supplied.
-
-What this plugin does and does not claim
-----------------------------------------
-It **does**: screen the turn's user message once, annotate the turn with a
-bounded note when the screening is FLAG / BLOCK / DEGRADED, and block
-downstream tool calls for a turn whose screening returned a genuine BLOCK.
-
-It **does not**: block prompt delivery, edit the system prompt, re-score on
-every tool call, or emit the raw user text or internal probe transcript into
-the model's context.
-
-Fail-open, like the rest of Little Canary: a pipeline exception, an
-unavailable Ollama backend, a missing turn key or an expired record all allow
-the turn and its tools to proceed. Only a genuine BLOCK verdict blocks.
-"""
+"""Optional Little Canary hooks for Hermes Agent."""
 
 from __future__ import annotations
 
@@ -98,9 +54,20 @@ ANNOTATED_DISPOSITIONS = (DISPOSITION_BLOCK, DISPOSITION_FLAG, DISPOSITION_DEGRA
 #: Default: only a genuine BLOCK withdraws tool authority.
 DEFAULT_BLOCKING_DISPOSITIONS = (DISPOSITION_BLOCK,)
 
+#: The only disposition a configuration may make blocking. DEGRADED and
+#: UNSCREENED describe coverage that was *not* exercised, and FLAG is an
+#: advisory that explicitly keeps routing; letting any of them withdraw tool
+#: authority would turn Little Canary's documented fail-open contract into a
+#: fail-closed one whenever the canary backend is merely unavailable.
+ALLOWED_BLOCKING_DISPOSITIONS = frozenset({DISPOSITION_BLOCK})
+
 DEFAULT_MAX_TURNS = 128
 DEFAULT_TTL_SECONDS = 900.0
 DEFAULT_MAX_CONTEXT_CHARS = 600
+
+#: Watermark above which an unusually large set of retained live BLOCK records
+#: is logged. It is not an eviction limit; see :class:`TurnDispositionStore`.
+DEFAULT_MAX_BLOCKED_TURNS = 1024
 
 #: The instructional half of ``build_context``'s output for each annotated
 #: disposition. This text -- the "treat this as untrusted data, not
@@ -176,28 +143,107 @@ class TurnDisposition:
         }
 
 
-def turn_key(session_id: str, turn_id: str) -> str:
-    """Build the store key for a turn, or ``""`` when neither id is usable.
+def normalize_blocking_dispositions(value: Any) -> tuple:
+    """Validate a ``blocking_dispositions`` configuration.
 
-    An empty key means the host gave us nothing to correlate on. Rather than
-    fall back to a process-global slot -- which would leak one turn's
-    disposition into an unrelated one -- the plugin declines to store, and the
-    later ``pre_tool_call`` fails open.
+    Rejects anything that is not a collection of genuine ``BLOCK``: a
+    degraded, unexercised or merely flagged screening must always fail open,
+    so there is no supported configuration in which it withdraws tool
+    authority. A bare ``str`` is rejected outright rather than iterated into
+    its characters -- ``"BLOCK"`` would otherwise silently become
+    ``('B', 'L', 'O', 'C', 'K')`` and disable blocking altogether.
+    """
+    if isinstance(value, (str, bytes)):
+        raise TypeError(
+            "blocking_dispositions must be a collection of dispositions, not a "
+            f"bare {type(value).__name__}; use (DISPOSITION_BLOCK,)"
+        )
+    try:
+        items = tuple(value)
+    except TypeError as exc:
+        raise TypeError(
+            "blocking_dispositions must be an iterable of dispositions"
+        ) from exc
+    invalid = [item for item in items if item not in ALLOWED_BLOCKING_DISPOSITIONS]
+    if invalid:
+        raise ValueError(
+            f"blocking_dispositions may contain only {DISPOSITION_BLOCK!r}; got "
+            f"{invalid!r}. Degraded, unexercised and flagged screening always fail "
+            "open by design, so they cannot be configured to block tool calls."
+        )
+    return tuple(dict.fromkeys(items))
+
+
+#: Separator between the session part and the turn part of a store key. The
+#: session part is length-prefixed, so this sequence occurring inside an id
+#: cannot be mistaken for the separator itself.
+KEY_SEPARATOR = "::"
+
+
+def session_prefix(session_id: str) -> str:
+    """Key prefix owned by one session, or ``""`` when the id is unusable.
+
+    The single source of truth for how a session is spelled inside a store
+    key: :func:`turn_key` builds on it and
+    :meth:`TurnDispositionStore.discard_session` matches on it, so the two can
+    never drift into different encodings.
     """
     session = (session_id or "").strip()
-    turn = (turn_id or "").strip()
-    if not session and not turn:
+    if not session:
         return ""
-    return f"{session}::{turn}"
+    return f"{len(session)}:{session}{KEY_SEPARATOR}"
+
+
+def turn_key(session_id: str, turn_id: str) -> str:
+    """Build the store key for a turn, or ``""`` when it cannot be correlated.
+
+    Both ids are required. A key built from only one of them would be shared
+    by every turn that is missing the other -- one turn's BLOCK would then
+    govern an unrelated turn in the same session, and a turn-only key would
+    collide across sessions. When either id is blank the plugin declines to
+    store, and the later ``pre_tool_call`` fails open: no key is safer than an
+    ambiguous one.
+
+    The encoding is collision-free. The session part is length-prefixed
+    (``"<len>:<session>::<turn>"``), so the key parses back to exactly one
+    ``(session, turn)`` pair: the digits before the first ``":"`` fix the
+    session's length, which fixes the session, which fixes the turn. Ids that
+    themselves contain ``"::"`` therefore cannot be re-cut into a different
+    pair -- ``("a::b", "c")`` and ``("a", "b::c")`` produce different keys.
+    """
+    prefix = session_prefix(session_id)
+    turn = (turn_id or "").strip()
+    if not prefix or not turn:
+        return ""
+    return f"{prefix}{turn}"
 
 
 class TurnDispositionStore:
     """Bounded, TTL-evicting, thread-safe map of turn key -> disposition.
 
     Deliberately not an unbounded module-level dict: a long-lived agent
-    process would otherwise accumulate one entry per turn forever. Capacity is
-    enforced by LRU eviction and age by TTL, so stale state cannot outlive its
-    turn or crowd out live turns.
+    process would otherwise accumulate one entry per turn forever.
+
+    Capacity and security are not symmetric here, so they are enforced
+    differently:
+
+    * **Non-blocking records** (PASS, FLAG, DEGRADED, UNSCREENED) are bounded
+      by ``max_turns`` and evicted least-recently-used first. Losing one is
+      harmless: ``pre_tool_call`` treats a missing record exactly as it treats
+      those dispositions -- allow.
+    * **Live blocking records** are never evicted to make room. Capacity
+      eviction of a live BLOCK would silently convert a refused turn into an
+      allowed one, so a burst of unrelated turns could buy back the tool
+      authority a BLOCK had just withdrawn. A blocking record leaves this
+      store only when it expires (``ttl_seconds``), when its session ends, or
+      on :meth:`clear`.
+
+    The bound on blocking records is therefore ``ttl_seconds``, not
+    ``max_turns``: at most the BLOCK verdicts the screening pipeline can
+    actually produce within one TTL window are held at once.
+    ``max_blocked_turns`` is a saturation watermark that logs when that set
+    grows unexpectedly large -- it is deliberately not a reaper, because
+    dropping a live BLOCK is the exact failure this store exists to prevent.
     """
 
     def __init__(
@@ -205,20 +251,35 @@ class TurnDispositionStore:
         max_turns: int = DEFAULT_MAX_TURNS,
         ttl_seconds: float = DEFAULT_TTL_SECONDS,
         time_source: TimeSource = time.monotonic,
+        max_blocked_turns: int | None = None,
     ) -> None:
         if max_turns < 1:
             raise ValueError("max_turns must be >= 1")
         if ttl_seconds <= 0:
             raise ValueError("ttl_seconds must be > 0")
+        if max_blocked_turns is not None and max_blocked_turns < 1:
+            raise ValueError("max_blocked_turns must be >= 1")
         self.max_turns = int(max_turns)
         self.ttl_seconds = float(ttl_seconds)
+        self.max_blocked_turns = (
+            int(max_blocked_turns)
+            if max_blocked_turns is not None
+            else max(int(max_turns), DEFAULT_MAX_BLOCKED_TURNS)
+        )
         self._time = time_source
         self._lock = threading.Lock()
         self._entries: OrderedDict[str, TurnDisposition] = OrderedDict()
+        self._saturation_reported = False
 
     def __len__(self) -> int:
         with self._lock:
             return len(self._entries)
+
+    def blocking_len(self) -> int:
+        """Number of live blocking records currently held."""
+        with self._lock:
+            self._purge_expired_locked()
+            return sum(1 for record in self._entries.values() if record.blocks_tools)
 
     def put(self, key: str, record: TurnDisposition) -> None:
         """Store a disposition, purging expired entries and enforcing capacity."""
@@ -228,8 +289,44 @@ class TurnDispositionStore:
             self._purge_expired_locked()
             self._entries[key] = record
             self._entries.move_to_end(key)
-            while len(self._entries) > self.max_turns:
-                self._entries.popitem(last=False)
+            self._enforce_capacity_locked(record)
+
+    def _enforce_capacity_locked(self, stored: TurnDisposition) -> None:
+        """Trim to ``max_turns`` without ever evicting a live blocking record.
+
+        Eviction walks in least-recently-used order and skips blocking
+        records. When the live blocks alone fill the capacity, the record that
+        cannot be kept is a *non-blocking* one (possibly the one just stored);
+        dropping it is indistinguishable from having recorded the PASS,
+        DEGRADED or UNSCREENED it carried, since all three allow tools anyway.
+        """
+        if len(self._entries) > self.max_turns:
+            for key in list(self._entries):
+                if len(self._entries) <= self.max_turns:
+                    break
+                if self._entries[key].blocks_tools:
+                    continue
+                del self._entries[key]
+
+        # The retained-block set can only have grown if the stored record is
+        # itself a block, so the count is not walked on every put.
+        if not stored.blocks_tools:
+            return
+        blocked = sum(1 for record in self._entries.values() if record.blocks_tools)
+        if blocked > self.max_blocked_turns:
+            if not self._saturation_reported:
+                logger.warning(
+                    "little-canary is holding %d live BLOCK turn record(s), above the "
+                    "max_blocked_turns watermark of %d; they are retained rather than "
+                    "evicted so no refused turn regains tool authority, and they expire "
+                    "after ttl_seconds=%.0f",
+                    blocked,
+                    self.max_blocked_turns,
+                    self.ttl_seconds,
+                )
+                self._saturation_reported = True
+        else:
+            self._saturation_reported = False
 
     def get(self, key: str) -> TurnDisposition | None:
         """Return a live disposition, or ``None`` when absent or expired."""
@@ -243,11 +340,15 @@ class TurnDispositionStore:
             return record
 
     def discard_session(self, session_id: str) -> int:
-        """Drop every entry for one session. Returns the number removed."""
-        session = (session_id or "").strip()
-        if not session:
+        """Drop every entry for one session. Returns the number removed.
+
+        Matches on :func:`session_prefix`, the same length-prefixed encoding
+        :func:`turn_key` writes, so ending session ``"a"`` cannot also sweep
+        away the live records of a different session such as ``"a::b"``.
+        """
+        prefix = session_prefix(session_id)
+        if not prefix:
             return 0
-        prefix = f"{session}::"
         with self._lock:
             doomed = [k for k in self._entries if k.startswith(prefix)]
             for key in doomed:
@@ -305,10 +406,21 @@ class LittleCanaryHermesPlugin:
         self._checker_lock = threading.Lock()
         self._time = time_source
         self.max_context_chars = int(max_context_chars)
-        self.blocking_dispositions = tuple(blocking_dispositions)
+        # Validated through the property setter, so a later reassignment is
+        # checked too.
+        self.blocking_dispositions = blocking_dispositions
         self.store = TurnDispositionStore(
             max_turns=max_turns, ttl_seconds=ttl_seconds, time_source=time_source
         )
+
+    @property
+    def blocking_dispositions(self) -> tuple:
+        """Dispositions that withdraw tool authority; only ``BLOCK`` is valid."""
+        return self._blocking_dispositions
+
+    @blocking_dispositions.setter
+    def blocking_dispositions(self, value: Any) -> None:
+        self._blocking_dispositions = normalize_blocking_dispositions(value)
 
     # -- checker resolution -------------------------------------------------
 
@@ -466,7 +578,12 @@ class LittleCanaryHermesPlugin:
             record = self.store.get(turn_key(session_id, turn_id))
             if record is None:
                 return None
-            if record.disposition not in self.blocking_dispositions:
+            # Two independent guards, so no configuration and no later
+            # mutation of ``_blocking_dispositions`` can make a non-BLOCK
+            # disposition withhold a tool call.
+            if not record.blocks_tools:
+                return None
+            if record.disposition not in self._blocking_dispositions:
                 return None
             return {"action": "block", "message": self.build_block_message(record, tool_name)}
         except Exception as exc:  # pragma: no cover - absolute fail-open net

--- a/tests/test_hermes_agent_plugin.py
+++ b/tests/test_hermes_agent_plugin.py
@@ -546,6 +546,32 @@ class TestTurnKeyEncoding:
         assert session_prefix("") == ""
         assert session_prefix("   ") == ""
 
+    @pytest.mark.parametrize(
+        ("session_id", "turn_id"),
+        [("s", " 1 "), (" s ", "1")],
+    )
+    def test_whitespace_variant_ids_do_not_inherit_a_block(self, session_id, turn_id):
+        plugin = _plugin(lambda _t: _verdict(safe=False))
+        plugin.pre_llm_call(user_message="bad", session_id="s", turn_id="1")
+
+        # Pre-fix both ids were stripped before encoding, so this never-screened
+        # variant read the screened turn's BLOCK.
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="1") is not None
+        assert plugin.pre_tool_call(tool_name="bash", session_id=session_id, turn_id=turn_id) is None
+
+    def test_session_cleanup_does_not_sweep_a_whitespace_variant_session(self):
+        plugin = _plugin(lambda _t: _verdict(safe=False))
+        plugin.pre_llm_call(user_message="bad", session_id="a", turn_id="1")
+        plugin.pre_llm_call(user_message="bad", session_id=" a ", turn_id="1")
+        assert len(plugin.store) == 2
+
+        # Ending session "a" must leave the distinct session " a " intact, and
+        # its live BLOCK must still withdraw tool authority.
+        assert plugin.on_session_end(session_id="a") is None
+        assert plugin.store.get(turn_key("a", "1")) is None
+        assert plugin.store.get(turn_key(" a ", "1")) is not None
+        assert plugin.pre_tool_call(tool_name="bash", session_id=" a ", turn_id="1") is not None
+
 
 # ---------------------------------------------------------------------------
 # Capacity must never revoke a live BLOCK (CodeRabbit: LRU eviction)

--- a/tests/test_hermes_agent_plugin.py
+++ b/tests/test_hermes_agent_plugin.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from little_canary.hermes_agent_plugin import (
+    DEFAULT_BLOCKING_DISPOSITIONS,
     DISPOSITION_BLOCK,
     DISPOSITION_DEGRADED,
     DISPOSITION_FLAG,
@@ -29,7 +30,9 @@ from little_canary.hermes_agent_plugin import (
     LittleCanaryHermesPlugin,
     TurnDisposition,
     TurnDispositionStore,
+    normalize_blocking_dispositions,
     register,
+    session_prefix,
     turn_key,
 )
 from little_canary.pipeline import PipelineVerdict, SecurityAdvisory, SecurityPipeline
@@ -90,6 +93,11 @@ def _verdict(
 
 def _plugin(checker, **kwargs) -> LittleCanaryHermesPlugin:
     return LittleCanaryHermesPlugin(checker=checker, **kwargs)
+
+
+def _record(disposition: str, created_at: float) -> TurnDisposition:
+    """A store record stamped with a clock the test controls."""
+    return TurnDisposition(disposition=disposition, created_at=created_at)
 
 
 def _fixed_clock():
@@ -249,10 +257,15 @@ class TestIsolation:
         assert len(plugin.store) == 0
         assert plugin.pre_tool_call(tool_name="bash", session_id="", turn_id="") is None
 
-    def test_turn_key_requires_at_least_one_id(self):
+    def test_turn_key_requires_both_ids(self):
+        # A key built from only one id is shared by every turn missing the
+        # other, so one turn's BLOCK would govern an unrelated turn.
         assert turn_key("", "") == ""
-        assert turn_key("s", "") == "s::"
-        assert turn_key("", "1") == "::1"
+        assert turn_key("s", "") == ""
+        assert turn_key("", "1") == ""
+        assert turn_key("  ", "1") == ""
+        assert turn_key("s", "  ") == ""
+        assert turn_key("s", "1") != ""
 
 
 # ---------------------------------------------------------------------------
@@ -473,3 +486,229 @@ class TestRealPipeline:
     def test_default_checker_is_built_lazily(self):
         plugin = LittleCanaryHermesPlugin()
         assert plugin._checker is None
+
+
+# ---------------------------------------------------------------------------
+# Turn-key encoding (CodeRabbit: ambiguous keys and partial ids)
+# ---------------------------------------------------------------------------
+
+
+class TestTurnKeyEncoding:
+    def test_ids_containing_the_separator_do_not_collide(self):
+        assert turn_key("a::b", "c") != turn_key("a", "b::c")
+        assert turn_key("a", "b::c") != turn_key("a::b", "c")
+        assert turn_key("1:a", "b") != turn_key("1", ":a::b")
+
+    def test_colliding_ids_do_not_share_a_disposition(self):
+        plugin = _plugin(lambda _t: _verdict(safe=False))
+        plugin.pre_llm_call(user_message="bad", session_id="a::b", turn_id="c")
+
+        # Pre-fix both turns hashed to "a::b::c", so this never-screened turn
+        # inherited the other turn's BLOCK.
+        assert plugin.pre_tool_call(tool_name="bash", session_id="a::b", turn_id="c") is not None
+        assert plugin.pre_tool_call(tool_name="bash", session_id="a", turn_id="b::c") is None
+
+    def test_missing_turn_id_is_not_stored_under_a_session_wide_key(self):
+        plugin = _plugin(lambda _t: _verdict(safe=False))
+        result = plugin.pre_llm_call(user_message="bad", session_id="s", turn_id="")
+
+        # The turn is still annotated, but nothing is parked under a key that
+        # every other turn_id-less turn of this session would also read.
+        assert DISPOSITION_BLOCK in result["context"]
+        assert len(plugin.store) == 0
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="") is None
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="9") is None
+
+    def test_missing_session_id_is_not_stored_under_a_turn_wide_key(self):
+        plugin = _plugin(lambda _t: _verdict(safe=False))
+        plugin.pre_llm_call(user_message="bad", session_id="", turn_id="1")
+        assert len(plugin.store) == 0
+        # A turn-only key would have been shared by turn "1" of every session.
+        assert plugin.pre_tool_call(tool_name="bash", session_id="other", turn_id="1") is None
+
+    def test_session_cleanup_uses_the_same_encoding_as_turn_key(self):
+        plugin = _plugin(lambda _t: _verdict(safe=False))
+        plugin.pre_llm_call(user_message="bad", session_id="a::b", turn_id="1")
+        plugin.pre_llm_call(user_message="bad", session_id="a", turn_id="1")
+
+        # Ending session "a" must not sweep away session "a::b" -- a plain
+        # "a::" prefix match did exactly that.
+        assert plugin.on_session_end(session_id="a") is None
+        assert plugin.store.get(turn_key("a", "1")) is None
+        assert plugin.store.get(turn_key("a::b", "1")) is not None
+        assert plugin.pre_tool_call(tool_name="bash", session_id="a::b", turn_id="1") is not None
+
+    def test_session_prefix_is_the_prefix_of_that_session_keys_only(self):
+        prefix = session_prefix("a")
+        assert turn_key("a", "1").startswith(prefix)
+        assert not turn_key("a::b", "1").startswith(prefix)
+        assert not turn_key("ab", "1").startswith(prefix)
+        assert session_prefix("") == ""
+        assert session_prefix("   ") == ""
+
+
+# ---------------------------------------------------------------------------
+# Capacity must never revoke a live BLOCK (CodeRabbit: LRU eviction)
+# ---------------------------------------------------------------------------
+
+
+class TestProtectedBlocks:
+    def test_capacity_pressure_does_not_restore_tool_authority(self):
+        plugin = _plugin(lambda text: _verdict(safe=(text != "bad")), max_turns=3)
+        plugin.pre_llm_call(user_message="bad", session_id="s", turn_id="blocked")
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="blocked") is not None
+
+        # Pre-fix, a handful of unrelated turns evicted the BLOCK and the
+        # refused turn's tool call was allowed again.
+        for i in range(20):
+            plugin.pre_llm_call(user_message="ok", session_id="s", turn_id=f"pass{i}")
+
+        directive = plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="blocked")
+        assert directive is not None and directive["action"] == "block"
+
+    def test_many_blocks_are_all_retained_under_capacity_pressure(self):
+        plugin = _plugin(lambda text: _verdict(safe=(text != "bad")), max_turns=2)
+        for i in range(10):
+            plugin.pre_llm_call(user_message="bad", session_id="s", turn_id=f"b{i}")
+        for i in range(10):
+            plugin.pre_llm_call(user_message="ok", session_id="s", turn_id=f"p{i}")
+
+        for i in range(10):
+            assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id=f"b{i}") is not None
+        assert plugin.store.blocking_len() == 10
+
+    def test_non_blocking_records_are_still_bounded_by_capacity(self):
+        state, clock = _fixed_clock()
+        store = TurnDispositionStore(max_turns=3, time_source=clock)
+        store.put(turn_key("s", "blocked"), _record(DISPOSITION_BLOCK, state["now"]))
+        for i in range(10):
+            store.put(turn_key("s", str(i)), _record(DISPOSITION_PASS, state["now"]))
+
+        # The block is kept; the evictable records stay within capacity.
+        assert store.get(turn_key("s", "blocked")) is not None
+        non_blocking = len(store) - store.blocking_len()
+        assert non_blocking <= 3
+        assert store.get(turn_key("s", "0")) is None
+
+    def test_expired_block_is_still_dropped_and_fails_open(self):
+        state, clock = _fixed_clock()
+        plugin = _plugin(
+            lambda _t: _verdict(safe=False), max_turns=2, ttl_seconds=60.0, time_source=clock
+        )
+        for i in range(5):
+            plugin.pre_llm_call(user_message="bad", session_id="s", turn_id=str(i))
+        assert plugin.store.blocking_len() == 5
+
+        state["now"] += 61.0
+        # TTL, not capacity, is what bounds retained blocks.
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="0") is None
+        assert len(plugin.store) == 0
+
+    def test_session_end_still_drops_that_sessions_blocks(self):
+        plugin = _plugin(lambda _t: _verdict(safe=False), max_turns=2)
+        for i in range(5):
+            plugin.pre_llm_call(user_message="bad", session_id="s1", turn_id=str(i))
+        plugin.pre_llm_call(user_message="bad", session_id="s2", turn_id="0")
+
+        assert plugin.on_session_end(session_id="s1") is None
+        assert plugin.store.blocking_len() == 1
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s1", turn_id="0") is None
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s2", turn_id="0") is not None
+
+    def test_block_saturation_is_reported_but_never_evicted(self, caplog):
+        state, clock = _fixed_clock()
+        store = TurnDispositionStore(max_turns=1, max_blocked_turns=2, time_source=clock)
+        with caplog.at_level("WARNING", logger="little_canary.hermes_agent_plugin"):
+            for i in range(4):
+                store.put(turn_key("s", str(i)), _record(DISPOSITION_BLOCK, state["now"]))
+
+        assert store.blocking_len() == 4
+        assert all(store.get(turn_key("s", str(i))) is not None for i in range(4))
+        assert "max_blocked_turns" in caplog.text
+
+    def test_saturation_is_reported_without_capacity_pressure(self, caplog):
+        # max_blocked_turns below max_turns: the watermark is crossed while
+        # the store is still well within its capacity.
+        state, clock = _fixed_clock()
+        store = TurnDispositionStore(max_turns=10, max_blocked_turns=2, time_source=clock)
+        with caplog.at_level("WARNING", logger="little_canary.hermes_agent_plugin"):
+            for i in range(4):
+                store.put(turn_key("s", str(i)), _record(DISPOSITION_BLOCK, state["now"]))
+
+        assert len(store) == 4
+        assert store.blocking_len() == 4
+        assert "max_blocked_turns" in caplog.text
+
+    def test_store_rejects_invalid_blocked_watermark(self):
+        with pytest.raises(ValueError):
+            TurnDispositionStore(max_blocked_turns=0)
+
+
+# ---------------------------------------------------------------------------
+# Only a genuine BLOCK may be configured as blocking
+# ---------------------------------------------------------------------------
+
+
+class TestBlockingConfiguration:
+    @pytest.mark.parametrize(
+        "configured",
+        [
+            (DISPOSITION_DEGRADED,),
+            (DISPOSITION_UNSCREENED,),
+            (DISPOSITION_FLAG,),
+            (DISPOSITION_PASS,),
+            (DISPOSITION_BLOCK, DISPOSITION_DEGRADED),
+            ("block",),
+            ("",),
+        ],
+    )
+    def test_unsafe_blocking_configuration_is_rejected(self, configured):
+        with pytest.raises(ValueError):
+            LittleCanaryHermesPlugin(
+                checker=lambda _t: _verdict(safe=True), blocking_dispositions=configured
+            )
+
+    def test_bare_string_configuration_is_rejected(self):
+        # tuple("BLOCK") is ('B','L','O','C','K'), which silently blocks
+        # nothing at all; that must not be accepted as a configuration.
+        with pytest.raises(TypeError):
+            LittleCanaryHermesPlugin(
+                checker=lambda _t: _verdict(safe=True), blocking_dispositions="BLOCK"
+            )
+
+    def test_non_iterable_configuration_is_rejected(self):
+        with pytest.raises(TypeError):
+            LittleCanaryHermesPlugin(
+                checker=lambda _t: _verdict(safe=True), blocking_dispositions=7
+            )
+
+    def test_valid_configurations_are_accepted_and_deduped(self):
+        assert normalize_blocking_dispositions(DEFAULT_BLOCKING_DISPOSITIONS) == (
+            DISPOSITION_BLOCK,
+        )
+        assert normalize_blocking_dispositions([DISPOSITION_BLOCK, DISPOSITION_BLOCK]) == (
+            DISPOSITION_BLOCK,
+        )
+        assert normalize_blocking_dispositions({DISPOSITION_BLOCK}) == (DISPOSITION_BLOCK,)
+        # Monitor-only: nothing blocks. Strictly fail-open, so it is allowed.
+        assert normalize_blocking_dispositions(()) == ()
+
+    def test_reassignment_is_validated_too(self):
+        plugin = _plugin(lambda _t: _verdict(safe=True, degraded=True))
+        with pytest.raises(ValueError):
+            plugin.blocking_dispositions = (DISPOSITION_DEGRADED,)
+        assert plugin.blocking_dispositions == (DISPOSITION_BLOCK,)
+
+    def test_degraded_never_blocks_even_if_the_setter_is_bypassed(self):
+        plugin = _plugin(lambda _t: _verdict(safe=True, degraded=True))
+        plugin.pre_llm_call(user_message="hi", session_id="s", turn_id="1")
+        # Tamper with the private attribute directly, skipping validation.
+        plugin._blocking_dispositions = (DISPOSITION_DEGRADED, DISPOSITION_BLOCK)
+        assert plugin.store.get(turn_key("s", "1")).disposition == DISPOSITION_DEGRADED
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="1") is None
+
+    def test_monitor_only_configuration_allows_a_blocked_turn(self):
+        plugin = _plugin(lambda _t: _verdict(safe=False), blocking_dispositions=())
+        result = plugin.pre_llm_call(user_message="bad", session_id="s", turn_id="1")
+        assert DISPOSITION_BLOCK in result["context"]
+        assert plugin.pre_tool_call(tool_name="bash", session_id="s", turn_id="1") is None


### PR DESCRIPTION
Fixes remaining valid #74 findings: collision-free complete turn keys, retention of live BLOCK records under capacity pressure, and a configuration guard that keeps degraded/flagged/unseen coverage fail-open. Adds focused regression coverage.\n\nValidation: `python3 -m pytest -q tests/test_hermes_agent_plugin.py` (65 passed); `ruff check little_canary/hermes_agent_plugin.py tests/test_hermes_agent_plugin.py`; `hermes-gate fast` PASS. Independent review pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against ambiguous session and turn identifiers, preventing records from being incorrectly matched.
  - Active blocking records now remain effective when storage capacity is reached.
  - Tool calls are blocked only when both the recorded disposition and current configuration explicitly require blocking.
  - Invalid blocking configurations and incomplete identifiers are rejected consistently.

- **Monitoring**
  - Added visibility into blocked-record saturation to help identify capacity pressure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->